### PR TITLE
Fix process pool not being shut down on exit

### DIFF
--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -140,6 +140,9 @@ class MusicModule(commands.Cog, CogFactory):
         extractor = MusicExtractor(executor, bot.loop)
         return cls(bot, extractor)
 
+    async def cog_unload(self):
+        self.extractor.shutdown_executor()
+
     def __get_player(self, ctx):
         """Return a MusicPlayer instance for the channel in the current context."""
         return self.__players[ctx.voice_client.channel.id]

--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -162,8 +162,8 @@ class MusicModule(commands.Cog, CogFactory):
         )
         await player.disconnect()
 
-    @commands.Cog.listener()
-    async def on_voice_state_update(self, _, before, after):
+    @commands.Cog.listener("on_voice_state_update")
+    async def _quit_channel_if_empty(self, _, before, after):
         """Leave voice channels that don't contain any other users."""
         if before.channel is not None and after.channel is None:
             if before.channel.members == [self.bot.user]:

--- a/acme_bot/music/extractor.py
+++ b/acme_bot/music/extractor.py
@@ -98,6 +98,7 @@ class MusicExtractor:
         log.info("Created the YoutubeDL instance for worker PID %s", getpid())
 
     def shutdown_executor(self):
+        """Clean up the executor associated with this MusicExtractor."""
         log.info("Shutting down pool executor for MusicExtractor")
         self.__executor.shutdown(cancel_futures=True)
 

--- a/acme_bot/music/extractor.py
+++ b/acme_bot/music/extractor.py
@@ -18,6 +18,7 @@ import logging
 from asyncio import gather
 from base64 import b64decode
 from json import loads
+from os import getpid
 from pathlib import PurePosixPath
 from time import time
 from typing import Optional
@@ -94,6 +95,11 @@ class MusicExtractor:
     def init_downloader(cls, constructor, *args):
         """Initialize the YoutubeDL instance for the current worker process."""
         cls.__DOWNLOADER = constructor(*args)
+        log.info("Created the YoutubeDL instance for worker PID %s", getpid())
+
+    def shutdown_executor(self):
+        log.info("Shutting down pool executor for MusicExtractor")
+        self.__executor.shutdown(cancel_futures=True)
 
     async def get_entries_by_urls(self, url_list):
         """Extract the track entries from the given URLs."""


### PR DESCRIPTION
The process pool is now shut down when the MusicModule is unloaded, providing the correct behavior when the bot exits.