### PR TITLE
Fix entry enumeration in selection menus

### DIFF
--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -510,11 +510,11 @@ class MusicModule(commands.Cog, CogFactory):
         """
         offset = int(offset)
         async with self.__get_player(ctx) as player:
-            removed = player.remove(offset)
+            removed = player.remove(offset - 1 if offset >= 1 else offset)
             if ctx.display:
                 await ctx.send_pages(
                     "\u2796 **{title}** by {uploader} "
-                    "removed from the playlist.".format(**removed)
+                    "removed from the queue.".format(**removed)
                 )
             return export_entry(removed)
 

--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -22,14 +22,15 @@ from itertools import chain
 from random import choices
 from shutil import which
 
-from discord import Embed, ButtonStyle, ui
+from discord import Embed
 from discord.ext import commands
 from yt_dlp import YoutubeDL
 
 from acme_bot.autoloader import CogFactory, autoloaded
 from acme_bot.config.properties import MUSIC_EXTRACTOR_MAX_WORKERS
-from acme_bot.music.extractor import MusicExtractor, add_expire_time
-from acme_bot.music.player import MusicPlayer, PlayerState
+from acme_bot.music.extractor import MusicExtractor
+from acme_bot.music.player import MusicPlayer
+from acme_bot.music.ui import ConfirmAddTracks, SelectTrack
 
 log = logging.getLogger(__name__)
 
@@ -64,101 +65,6 @@ def export_entry_list(*iterables):
 def strip_urls(urls):
     """Strip entry strings from their title and duration, leaving the URL."""
     return (line.split()[0] for line in urls.split("\n") if line)
-
-
-class ConfirmAddTracks(ui.View):
-    """Confirm/cancel menu view for the play-url command."""
-
-    ACTION_TIMEOUT = 60.0
-
-    def __init__(self, user, player, results):
-        super().__init__(timeout=self.ACTION_TIMEOUT)
-        self.__user = user
-        self.__player = player
-        self.__results = results
-
-    async def interaction_check(self, interaction):
-        return interaction.user == self.__user
-
-    @ui.button(label="Add to queue", emoji="\u2795", style=ButtonStyle.primary)
-    async def add_to_queue(self, interaction, _):
-        """Confirm adding tracks to the player."""
-        await interaction.message.edit(
-            content=f"\u2795 {len(self.__results)} tracks added to the queue.",
-            delete_after=None,
-            view=None,
-        )
-
-        async with self.__player as player:
-            for track in self.__results:
-                add_expire_time(track)
-            player.extend(self.__results)
-
-            if player.state == PlayerState.IDLE:
-                await player.start_player(self.__results[0])
-
-    @ui.button(label="Cancel", emoji="\U0001F6AB", style=ButtonStyle.secondary)
-    async def cancel(self, interaction, _):
-        """Cancel adding tracks to the player."""
-        await interaction.message.edit(
-            content="\U0001F6AB *Action cancelled.*", view=None
-        )
-
-
-class SelectTrack(ui.View):
-    """Select menu view for the play/play-snd command."""
-
-    ACTION_TIMEOUT = 60.0
-
-    def __init__(self, user, player, return_queue, results):
-        super().__init__(timeout=self.ACTION_TIMEOUT)
-
-        self.__user = user
-        self.__player = player
-        self.__return_queue = return_queue
-
-        for index, new in enumerate(results, start=1):
-            self.add_select_button(index, new)
-        self.add_cancel_button()
-
-    async def interaction_check(self, interaction):
-        return interaction.user == self.__user
-
-    def add_select_button(self, index, new):
-        """Create a button that adds the given track to the player."""
-
-        async def button_pressed(interaction):
-            add_expire_time(new)
-            async with self.__player as player:
-                player.append(new)
-
-                if player.state == PlayerState.IDLE:
-                    msg = "\u2795 **{title}** by {uploader} added to the queue.".format(
-                        **new
-                    )
-                    await player.start_player(new)
-                    await interaction.message.edit(
-                        content=msg, delete_after=None, view=None
-                    )
-            await self.__return_queue.put(new)
-
-        button = ui.Button(label=str(index), style=ButtonStyle.secondary)
-        button.callback = button_pressed
-        self.add_item(button)
-
-    def add_cancel_button(self):
-        """Cancel adding tracks to the player."""
-
-        async def button_pressed(interaction):
-            await interaction.message.edit(
-                content="\U0001F6AB *Action cancelled.*", view=None
-            )
-
-        button = ui.Button(
-            label="Cancel", emoji="\U0001F6AB", style=ButtonStyle.secondary
-        )
-        button.callback = button_pressed
-        self.add_item(button)
 
 
 @autoloaded

--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -95,6 +95,7 @@ class ConfirmAddTracks(ui.View):
         """Confirm adding tracks to the player."""
         await interaction.message.edit(
             content=f"\u2795 {len(self.__results)} tracks added to the queue.",
+            delete_after=None,
             view=None,
         )
 

--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -183,9 +183,9 @@ class MusicModule(commands.Cog, CogFactory):
 
     @commands.Cog.listener("on_voice_state_update")
     async def _quit_channel_if_empty(self, _, before, after):
-        """Leave voice channels that don't contain any other users."""
+        """Leave voice channels that don't contain any human users."""
         if before.channel is not None and after.channel is None:
-            if before.channel.members == [self.bot.user]:
+            if all(user.bot for user in before.channel.members):
                 log.info(
                     "Voice channel ID %s is now empty, disconnecting",
                     before.channel.id,

--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -22,6 +22,7 @@ from itertools import chain
 from random import choices
 from shutil import which
 
+from discord import Embed
 from discord.ext import commands
 from yt_dlp import YoutubeDL
 
@@ -478,10 +479,15 @@ class MusicModule(commands.Cog, CogFactory):
         async with self.__get_player(ctx) as player:
             current = player.current
             if ctx.display:
-                await ctx.send_pages(
-                    "\u25B6 Playing **{title}** by {uploader} now."
-                    "\n{webpage_url}".format(**current)
+                embed = Embed(
+                    title=f"\u25B6 Now playing: {current['title']}",
+                    description=f"by {current['uploader']}",
+                    color=0xFF0000,
+                    url=current["webpage_url"],
                 )
+                if "thumbnail" in current:
+                    embed.set_thumbnail(url=current["thumbnail"])
+                await ctx.send(embed=embed)
             return export_entry(current)
 
     @commands.command(aliases=["remo"])

--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -34,35 +34,19 @@ from acme_bot.music.player import MusicPlayer, PlayerState
 log = logging.getLogger(__name__)
 
 
-def assemble_menu(header, entries):
-    """Create a menu with the given header and information about the queue entries."""
-    menu = header
-    for index, entry in enumerate(entries):
-        menu += "\n{}. **{title}** - {uploader} - {duration_string}".format(
-            index, **entry
-        )
-    return menu
-
-
-def pred_select(ctx, results):
-    """Create a predicate function for use with wait_for and selections from a list."""
-
-    def pred(msg):
-        return (
-            msg.channel == ctx.channel
-            and msg.author == ctx.author
-            and msg.content.isnumeric()
-            and (0 <= int(msg.content) < len(results))
-        )
-
-    return pred
-
-
 def display_entry(entry):
     """Display an entry with the duration in MM:SS format."""
     return "{}. **{title}** - {uploader} - {duration_string}".format(
         entry[0], **entry[1]
     )
+
+
+def assemble_menu(header, entries):
+    """Create a menu with the given header and information about the queue entries."""
+    menu = header
+    for entry in enumerate(entries, start=1):
+        menu += f"\n{display_entry(entry)}"
+    return menu
 
 
 def export_entry(entry):

--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -188,6 +188,7 @@ class MusicModule(commands.Cog, CogFactory):
         await ctx.send_pages(
             assemble_menu("\u2049\uFE0F Choose one of the following results:", results),
             view=SelectTrack(ctx.author, self.__get_player(ctx), new, results),
+            reference=ctx.message,
         )
 
         new_entry = await new.get()
@@ -212,6 +213,7 @@ class MusicModule(commands.Cog, CogFactory):
         await ctx.send_pages(
             assemble_menu("\u2049\uFE0F Choose one of the following results:", results),
             view=SelectTrack(ctx.author, self.__get_player(ctx), new, results),
+            reference=ctx.message,
         )
 
         new_entry = await new.get()
@@ -235,6 +237,7 @@ class MusicModule(commands.Cog, CogFactory):
         await ctx.send(
             f"\u2705 Extracted {len(results)} tracks.",
             view=ConfirmAddTracks(ctx.author, self.__get_player(ctx), results),
+            reference=ctx.message,
         )
         return export_entry_list(results)
 

--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -83,6 +83,8 @@ def strip_urls(urls):
 
 
 class ConfirmAddTracks(ui.View):
+    """Confirm/cancel menu view for the play-url command."""
+
     def __init__(self, player, results):
         super().__init__()
         self.__player = player
@@ -90,6 +92,7 @@ class ConfirmAddTracks(ui.View):
 
     @ui.button(label="Add to queue", emoji="\u2795", style=ButtonStyle.primary)
     async def add_to_queue(self, interaction, _):
+        """Confirm adding tracks to the player."""
         await interaction.message.edit(
             content=f"\u2795 {len(self.__results)} tracks added to the queue.",
             view=None,
@@ -105,6 +108,7 @@ class ConfirmAddTracks(ui.View):
 
     @ui.button(label="Cancel", emoji="\U0001F6AB", style=ButtonStyle.secondary)
     async def cancel(self, interaction, _):
+        """Cancel adding tracks to the player."""
         await interaction.message.edit(
             content="\U0001F6AB *Action cancelled.*", view=None
         )

--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -136,13 +136,11 @@ class MusicModule(commands.Cog, CogFactory):
     @commands.Cog.listener("on_voice_state_update")
     async def _quit_channel_if_empty(self, _, before, after):
         """Leave voice channels that don't contain any human users."""
-        if before.channel is not None and after.channel is None:
-            if all(user.bot for user in before.channel.members):
-                log.info(
-                    "Voice channel ID %s is now empty, disconnecting",
-                    before.channel.id,
-                )
-                player = self.__players[before.channel.id]
+        voice = before.channel
+        if voice is not None and after.channel is None:
+            if voice.id in self.__players and all(user.bot for user in voice.members):
+                log.info("Voice channel ID %s is now empty, disconnecting", voice.id)
+                player = self.__players[voice.id]
                 await self.__delete_player(player)
 
     @commands.command()

--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -194,7 +194,9 @@ class MusicModule(commands.Cog, CogFactory):
             head, tail, _ = player.split_view()
             await self.__delete_player(player)
         if ctx.display:
-            await ctx.send("\u23CF Quitting the voice channel.")
+            await ctx.send(
+                f"\u23CF Quitting voice channel **{ctx.voice_client.channel.name}**."
+            )
         return format_entry_lists(export_entry, head, tail)
 
     @commands.command()

--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -210,10 +210,8 @@ class MusicModule(commands.Cog, CogFactory):
         """
         query = " ".join(str(part) for part in query)
         async with ctx.typing():
-            # Get video list for query
             results = await self.extractor.get_entries_by_query("ytsearch10:", query)
-            # Assemble and display menu
-            menu_msg = await ctx.send(
+            menu_msg = await ctx.send_pages(
                 assemble_menu("\u2049 Choose one of the following results:", results)
             )
 
@@ -226,16 +224,15 @@ class MusicModule(commands.Cog, CogFactory):
             return
 
         new = results[int(response.content)]
-        add_expire_time(new)  # Update the entry with its expiration time
+        add_expire_time(new)
 
         async with self.__get_player(ctx) as player:
-            player.append(new)  # Add the new entry to the player's queue
+            player.append(new)
 
             if player.state == PlayerState.IDLE:
-                # If the player is not playing, paused or stopped, start playing
                 await player.start_player(new)
             elif ctx.display:
-                await ctx.send(
+                await ctx.send_pages(
                     "\u2795 **{title}** by {uploader} added to the queue.".format(**new)
                 )
 
@@ -254,10 +251,8 @@ class MusicModule(commands.Cog, CogFactory):
         """
         query = " ".join(str(part) for part in query)
         async with ctx.typing():
-            # Get video list for query
             results = await self.extractor.get_entries_by_query("scsearch10:", query)
-            # Assemble and display menu
-            menu_msg = await ctx.send(
+            menu_msg = await ctx.send_pages(
                 assemble_menu("\u2049 Choose one of the following results:", results)
             )
 
@@ -270,16 +265,15 @@ class MusicModule(commands.Cog, CogFactory):
             return
 
         new = results[int(response.content)]
-        add_expire_time(new)  # Update the entry with its expiration time
+        add_expire_time(new)
 
         async with self.__get_player(ctx) as player:
-            player.append(new)  # Add the new entry to the player's queue
+            player.append(new)
 
             if player.state == PlayerState.IDLE:
-                # If the player is not playing, paused or stopped, start playing
                 await player.start_player(new)
             elif ctx.display:
-                await ctx.send(
+                await ctx.send_pages(
                     "\u2795 **{title}** by {uploader} added to the queue.".format(**new)
                 )
 
@@ -298,13 +292,11 @@ class MusicModule(commands.Cog, CogFactory):
         """
         url_list = "\n".join(str(url) for url in urls)
         async with ctx.typing():
-            # Get the tracks from the given URL list
             results = await self.extractor.get_entries_by_urls(extract_urls(url_list))
-            # Assemble and display menu
             menu_msg = await ctx.send(
                 f"\u2049 Do you want to add {len(results)} tracks to the queue?"
             )
-            # Add the reactions used to confirm or cancel the action
+            # Add reactions to confirm or cancel the action
             await menu_msg.add_reaction("\u2714")
             await menu_msg.add_reaction("\u274C")
 
@@ -327,13 +319,12 @@ class MusicModule(commands.Cog, CogFactory):
             await ctx.send(f"\u2795 {len(results)} tracks added to the queue.")
 
         async with self.__get_player(ctx) as player:
-            player.extend(results)  # Add the new entries to the player's queue
+            for track in results:
+                add_expire_time(track)
+            player.extend(results)
 
-            for elem in results:
-                add_expire_time(elem)  # Update the new entry with its expiration time
-                if player.state == PlayerState.IDLE:
-                    # If the player is not playing, paused or stopped, start playing
-                    await player.start_player(elem)
+            if player.state == PlayerState.IDLE:
+                await player.start_player(results[0])
 
         return format_entry_lists(export_entry, results)
 
@@ -485,7 +476,7 @@ class MusicModule(commands.Cog, CogFactory):
         async with self.__get_player(ctx) as player:
             current = player.current
             if ctx.display:
-                await ctx.send(
+                await ctx.send_pages(
                     "\u25B6 Playing **{title}** by {uploader} now."
                     "\n{webpage_url}".format(**current)
                 )
@@ -506,7 +497,7 @@ class MusicModule(commands.Cog, CogFactory):
         async with self.__get_player(ctx) as player:
             removed = player.remove(offset)
             if ctx.display:
-                await ctx.send(
+                await ctx.send_pages(
                     "\u2796 **{title}** by {uploader} "
                     "removed from the playlist.".format(**removed)
                 )

--- a/acme_bot/music/extractor.py
+++ b/acme_bot/music/extractor.py
@@ -36,7 +36,6 @@ def add_expire_time(entry):
     """Update the entry with its expiration time (kept as a Unix timestamp)."""
     try:
         url = urlparse(entry["url"])
-
         if entry["extractor"] == "youtube":
             if url.query:
                 # Usually the expiration time is in the `expire` part of the query
@@ -86,10 +85,6 @@ class MusicExtractor:
     def __init__(self, executor, loop):
         self.__executor = executor
         self.__loop = loop
-
-    @classmethod
-    def _extract_in_subprocess(cls, url):
-        return cls.__DOWNLOADER.extract_info(url, download=False)
 
     @classmethod
     def init_downloader(cls, constructor, *args):
@@ -143,5 +138,9 @@ class MusicExtractor:
 
         if not result or (result["extractor"] not in ("youtube", "soundcloud")):
             raise commands.CommandError(f"Incorrect track URL: {entry_url}")
-        add_expire_time(result)  # Add the expiration time to the entry
+        add_expire_time(result)
         entry.update(result)  # Update the entry in-place
+
+    @classmethod
+    def _extract_in_subprocess(cls, url):
+        return cls.__DOWNLOADER.extract_info(url, download=False)

--- a/acme_bot/music/extractor.py
+++ b/acme_bot/music/extractor.py
@@ -90,7 +90,7 @@ class MusicExtractor:
     def init_downloader(cls, constructor, *args):
         """Initialize the YoutubeDL instance for the current worker process."""
         cls.__DOWNLOADER = constructor(*args)
-        log.info("Created the YoutubeDL instance for worker (PID %s)", getpid())
+        log.info("Created YoutubeDL instance for worker (PID %s)", getpid())
 
     def shutdown_executor(self):
         """Clean up the executor associated with this MusicExtractor."""

--- a/acme_bot/music/player.py
+++ b/acme_bot/music/player.py
@@ -188,10 +188,10 @@ class MusicPlayer(MusicQueue):
     def remove(self, offset):
         """Remove a track from the player's queue."""
         removed = self._pop(offset)
-        if self.is_empty():  # If the queue is now empty, stop the player.
+        if self.is_empty():
             self.__state = PlayerState.IDLE
             self.__ctx.voice_client.stop()
-        elif offset == 0:  # If the current track is removed, start playing the next.
+        elif offset == 0:  # Current track was removed, start playing the next one.
             self.__next_offset = 0
             self.__ctx.voice_client.stop()
         return removed
@@ -237,21 +237,19 @@ class MusicPlayer(MusicQueue):
             if err:
                 log.error(err)
                 return
-            # Stop if queue looping is off and the last song has finished playing
             if (
                 self._should_stop(self.__next_offset)
                 and self.__state == PlayerState.PLAYING
             ):
                 self.__state = PlayerState.STOPPED
                 run_coroutine_threadsafe(
-                    self.__ctx.send("The queue is empty, resume to keep playing."),
+                    self.__ctx.send("\u2757 The queue is empty, stopping the player."),
                     self.__ctx.bot.loop,
                 )
                 return
-            # Advance the queue if it's not empty
             if self.__state in (PlayerState.PLAYING, PlayerState.PAUSED):
                 current = self._next(self.__next_offset)
-                self.__next_offset = 1  # Reset next_offset to the default value of 1
+                self.__next_offset = 1  # Set next_offset back to the default value of 1
                 run_coroutine_threadsafe(
                     self.start_player(current), self.__ctx.bot.loop
                 )

--- a/acme_bot/music/queue.py
+++ b/acme_bot/music/queue.py
@@ -57,7 +57,7 @@ class MusicQueue:
         if self.is_empty():
             raise IndexError("queue index out of range")
 
-        self.__index = (self.__index + offset) % len(self.__playlist)
+        self.__index = self.__next_index(offset)
         return self.current
 
     def _should_stop(self, offset):
@@ -71,4 +71,7 @@ class MusicQueue:
         if self.is_empty():
             raise IndexError("queue index out of range")
 
-        return self.__playlist.pop((self.__index + offset) % len(self.__playlist))
+        return self.__playlist.pop(self.__next_index(offset))
+
+    def __next_index(self, offset):
+        return (self.__index + offset) % len(self.__playlist)

--- a/acme_bot/music/queue.py
+++ b/acme_bot/music/queue.py
@@ -40,12 +40,11 @@ class MusicQueue:
         """Return True if the queue is empty."""
         return not self.__playlist
 
-    def split_view(self):
-        """Return the queue head, tail and split offset."""
+    def get_tracks(self):
+        """Return the queue head and tail."""
         return (
             self.__playlist[self.__index :],
             self.__playlist[: self.__index],
-            len(self.__playlist) - self.__index,
         )
 
     def _clear(self):

--- a/acme_bot/music/queue.py
+++ b/acme_bot/music/queue.py
@@ -28,10 +28,30 @@ class MusicQueue:
         """Return the current track."""
         return self.__playlist[self.__index]
 
+    def append(self, new_elem):
+        """Add a single new element to the queue."""
+        self.__playlist.append(new_elem)
+
+    def extend(self, elem_list):
+        """Append an iterable of new elements to the queue."""
+        self.__playlist.extend(elem_list)
+
+    def is_empty(self):
+        """Return True if the queue is empty."""
+        return not self.__playlist
+
+    def split_view(self):
+        """Return the queue head, tail and split offset."""
+        return (
+            self.__playlist[self.__index :],
+            self.__playlist[: self.__index],
+            len(self.__playlist) - self.__index,
+        )
+
     def _clear(self):
         """Remove all elements from the queue."""
         self.__playlist.clear()
-        self.__index = 0  # Set the index to 0, as there is nothing in the queue
+        self.__index = 0  # Index of zero will point at the first appended track
 
     def _next(self, offset):
         """Return the next track based on the offset."""
@@ -53,23 +73,3 @@ class MusicQueue:
             raise IndexError("queue index out of range")
 
         return self.__playlist.pop((self.__index + offset) % len(self.__playlist))
-
-    def append(self, new_elem):
-        """Add a single new element to the queue."""
-        self.__playlist.append(new_elem)
-
-    def extend(self, elem_list):
-        """Append an iterable of new elements to the queue."""
-        self.__playlist.extend(elem_list)
-
-    def is_empty(self):
-        """Return True if the queue is empty."""
-        return not self.__playlist
-
-    def split_view(self):
-        """Return the queue head, tail and split offset."""
-        return (
-            self.__playlist[self.__index :],
-            self.__playlist[: self.__index],
-            len(self.__playlist) - self.__index,
-        )

--- a/acme_bot/music/ui.py
+++ b/acme_bot/music/ui.py
@@ -20,8 +20,8 @@ from acme_bot.music.extractor import add_expire_time
 from acme_bot.music.player import PlayerState
 
 
-class View(ui.View):
-    """Generic view with a timeout and interaction user verification."""
+class VerifiedView(ui.View):
+    """Generic view with interaction user verification."""
 
     ACTION_TIMEOUT = 60.0
 
@@ -33,7 +33,7 @@ class View(ui.View):
         return interaction.user == self.__user
 
 
-class ConfirmAddTracks(View):
+class ConfirmAddTracks(VerifiedView):
     """Confirm/cancel menu view for the play-url command."""
 
     def __init__(self, user, player, results):
@@ -66,7 +66,7 @@ class ConfirmAddTracks(View):
         )
 
 
-class SelectTrack(View):
+class SelectTrack(VerifiedView):
     """Select menu view for the play/play-snd command."""
 
     def __init__(self, user, player, return_queue, results):

--- a/acme_bot/music/ui.py
+++ b/acme_bot/music/ui.py
@@ -62,7 +62,7 @@ class ConfirmAddTracks(VerifiedView):
     async def cancel(self, interaction, _):
         """Cancel adding tracks to the player."""
         await interaction.message.edit(
-            content="\U0001F6AB *Action cancelled.*", view=None
+            content="\U0001F6AB *Action canceled.*", view=None
         )
 
 
@@ -106,7 +106,7 @@ class SelectTrack(VerifiedView):
 
         async def button_pressed(interaction):
             await interaction.message.edit(
-                content="\U0001F6AB *Action cancelled.*", view=None
+                content="\U0001F6AB *Action canceled.*", view=None
             )
 
         button = ui.Button(

--- a/acme_bot/music/ui.py
+++ b/acme_bot/music/ui.py
@@ -1,0 +1,116 @@
+"""Music command UI interactions based on discord.py View."""
+#  Copyright (C) 2023  Krzysztof Molski
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from discord import ui, ButtonStyle
+
+from acme_bot.music.extractor import add_expire_time
+from acme_bot.music.player import PlayerState
+
+
+class View(ui.View):
+    """Generic view with a timeout and interaction user verification."""
+
+    ACTION_TIMEOUT = 60.0
+
+    def __init__(self, user, timeout):
+        super().__init__(timeout=timeout)
+        self.__user = user
+
+    async def interaction_check(self, interaction, /):
+        return interaction.user == self.__user
+
+
+class ConfirmAddTracks(View):
+    """Confirm/cancel menu view for the play-url command."""
+
+    def __init__(self, user, player, results):
+        super().__init__(user, self.ACTION_TIMEOUT)
+        self.__player = player
+        self.__results = results
+
+    @ui.button(label="Add to queue", emoji="\u2795", style=ButtonStyle.primary)
+    async def add_to_queue(self, interaction, _):
+        """Confirm adding tracks to the player."""
+        await interaction.message.edit(
+            content=f"\u2795 {len(self.__results)} tracks added to the queue.",
+            delete_after=None,
+            view=None,
+        )
+
+        async with self.__player as player:
+            for track in self.__results:
+                add_expire_time(track)
+            player.extend(self.__results)
+
+            if player.state == PlayerState.IDLE:
+                await player.start_player(self.__results[0])
+
+    @ui.button(label="Cancel", emoji="\U0001F6AB", style=ButtonStyle.secondary)
+    async def cancel(self, interaction, _):
+        """Cancel adding tracks to the player."""
+        await interaction.message.edit(
+            content="\U0001F6AB *Action cancelled.*", view=None
+        )
+
+
+class SelectTrack(View):
+    """Select menu view for the play/play-snd command."""
+
+    def __init__(self, user, player, return_queue, results):
+        super().__init__(user, timeout=self.ACTION_TIMEOUT)
+
+        self.__player = player
+        self.__return_queue = return_queue
+
+        for index, new in enumerate(results, start=1):
+            self.add_select_button(index, new)
+        self.add_cancel_button()
+
+    def add_select_button(self, index, new):
+        """Create a button that adds the given track to the player."""
+
+        async def button_pressed(interaction):
+            add_expire_time(new)
+            async with self.__player as player:
+                player.append(new)
+
+                if player.state == PlayerState.IDLE:
+                    msg = "\u2795 **{title}** by {uploader} added to the queue.".format(
+                        **new
+                    )
+                    await player.start_player(new)
+                    await interaction.message.edit(
+                        content=msg, delete_after=None, view=None
+                    )
+            await self.__return_queue.put(new)
+
+        button = ui.Button(label=str(index), style=ButtonStyle.secondary)
+        button.callback = button_pressed
+        self.add_item(button)
+
+    def add_cancel_button(self):
+        """Cancel adding tracks to the player."""
+
+        async def button_pressed(interaction):
+            await interaction.message.edit(
+                content="\U0001F6AB *Action cancelled.*", view=None
+            )
+
+        button = ui.Button(
+            label="Cancel", emoji="\U0001F6AB", style=ButtonStyle.secondary
+        )
+        button.callback = button_pressed
+        self.add_item(button)

--- a/acme_bot/music/ui.py
+++ b/acme_bot/music/ui.py
@@ -46,7 +46,6 @@ class ConfirmAddTracks(VerifiedView):
         """Confirm adding tracks to the player."""
         await interaction.message.edit(
             content=f"\u2795 {len(self.__results)} tracks added to the queue.",
-            delete_after=None,
             view=None,
         )
 
@@ -84,17 +83,18 @@ class SelectTrack(VerifiedView):
 
         async def button_pressed(interaction):
             add_expire_time(new)
+            await interaction.message.edit(
+                content="\u2795 **{title}** by {uploader} added to the queue.".format(
+                    **new
+                ),
+                view=None,
+            )
+
             async with self.__player as player:
                 player.append(new)
 
                 if player.state == PlayerState.IDLE:
-                    msg = "\u2795 **{title}** by {uploader} added to the queue.".format(
-                        **new
-                    )
                     await player.start_player(new)
-                    await interaction.message.edit(
-                        content=msg, delete_after=None, view=None
-                    )
             await self.__return_queue.put(new)
 
         button = ui.Button(label=str(index), style=ButtonStyle.secondary)

--- a/acme_bot/textutils.py
+++ b/acme_bot/textutils.py
@@ -50,6 +50,7 @@ async def send_pages(
     *,
     fmt=None,
     view=None,
+    reference=None,
     delete_after=None,
     escape_md_blocks=False,
     max_length=MAX_MESSAGE_LENGTH
@@ -65,7 +66,9 @@ async def send_pages(
         if fmt is not None:
             chunk = fmt.format(chunk)
         chunk_view = view if i == len(msg_chunks) else None
-        await ctx.send(chunk, view=chunk_view, delete_after=delete_after)
+        await ctx.send(
+            chunk, delete_after=delete_after, reference=reference, view=chunk_view
+        )
 
 
 def escape_md_block(text):

--- a/acme_bot/textutils.py
+++ b/acme_bot/textutils.py
@@ -45,7 +45,14 @@ def _split_message(text, limit):
 
 
 async def send_pages(
-    ctx, content, *, fmt=None, escape_md_blocks=False, max_length=MAX_MESSAGE_LENGTH
+    ctx,
+    content,
+    *,
+    fmt=None,
+    view=None,
+    delete_after=None,
+    escape_md_blocks=False,
+    max_length=MAX_MESSAGE_LENGTH
 ):
     """Split and send a message with the specified content and format."""
     if escape_md_blocks:
@@ -53,10 +60,12 @@ async def send_pages(
     if fmt is not None:
         max_length -= len(fmt)
 
-    for chunk in _split_message(content, max_length):
+    msg_chunks = _split_message(content, max_length)
+    for i, chunk in enumerate(msg_chunks, start=1):
         if fmt is not None:
             chunk = fmt.format(chunk)
-        await ctx.send(chunk)
+        chunk_view = view if i == len(msg_chunks) else None
+        await ctx.send(chunk, view=chunk_view, delete_after=delete_after)
 
 
 def escape_md_block(text):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "acme-bot"
-version = "0.5.0-dev"
+version = "0.6.0-dev"
 description = "Discord music bot with a custom shell language"
 license = "AGPL-3.0-or-later"
 authors = ["kmolski <krzysztof.molski29@gmail.com>"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,4 @@
-from asyncio import get_running_loop, Queue
+from asyncio import get_running_loop, AbstractEventLoop, Queue
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 from typing import Optional
@@ -6,7 +6,7 @@ from typing import Optional
 import pytest
 
 from acme_bot.music.extractor import MusicExtractor
-from acme_bot.music.player import MusicPlayer
+from acme_bot.music.player import MusicPlayer, PlayerState
 from acme_bot.music.queue import MusicQueue
 from acme_bot.music.ui import ConfirmAddTracks, SelectTrack
 
@@ -39,8 +39,15 @@ class StubUser:
 
 
 @dataclass
+class StubBot:
+    """Stub discord.py bot instance object."""
+
+    loop: AbstractEventLoop
+
+
+@dataclass
 class FakeVoiceClient:
-    """Stub discord.py voice client object."""
+    """Fake discord.py voice client object."""
 
     played_tracks: list[object]
     channel: StubChannel
@@ -79,6 +86,7 @@ class FakeContext:
     references: list[object]
     views: list[object]
 
+    bot: StubBot
     voice_client: FakeVoiceClient
 
     async def send(
@@ -97,6 +105,49 @@ class FakeContext:
         self.delete_after.append(delete_after)
         self.references.append(reference)
         self.views.append(view)
+
+
+@dataclass
+class FakeMessage:
+    """Fake discord.py message object."""
+
+    content: str = ""
+    delete_after: float = None
+    view: object = None
+
+    async def edit(self, *, content=None, delete_after=None, view=None):
+        if content is not None:
+            self.content = content
+        if delete_after is not None:
+            self.delete_after = delete_after
+        if view is not None:
+            self.view = view
+
+
+class FakePlayer(MusicQueue):
+    """Fake acme_bot MusicPlayer object."""
+
+    def __init__(self):
+        super().__init__()
+        self.state = PlayerState.IDLE
+        self.playing = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_):
+        return False
+
+    async def start_player(self, playing):
+        self.state = PlayerState.PLAYING
+        self.playing = playing
+
+
+@dataclass
+class StubInteraction:
+    """Stub discord.py interaction object."""
+
+    message: FakeMessage
 
 
 @pytest.fixture
@@ -209,13 +260,18 @@ def stub_user():
 
 
 @pytest.fixture
+async def stub_bot():
+    return StubBot(get_running_loop())
+
+
+@pytest.fixture
 def fake_voice_client(stub_channel):
     return FakeVoiceClient([], stub_channel, None)
 
 
 @pytest.fixture
-def fake_ctx(fake_voice_client):
-    return FakeContext([], [], [], [], [], [], fake_voice_client)
+def fake_ctx(stub_bot, fake_voice_client):
+    return FakeContext([], [], [], [], [], [], stub_bot, fake_voice_client)
 
 
 @pytest.fixture
@@ -231,10 +287,25 @@ async def player_with_tracks(fake_ctx, stub_extractor, youtube_playlist):
 
 
 @pytest.fixture
-async def confirm_add_tracks_view(stub_user, player, youtube_playlist):
-    return ConfirmAddTracks(stub_user, player, youtube_playlist)
+def fake_message():
+    return FakeMessage()
 
 
 @pytest.fixture
-async def select_track_view(stub_user, player, youtube_playlist):
-    return SelectTrack(stub_user, player, Queue(), youtube_playlist)
+def fake_player():
+    return FakePlayer()
+
+
+@pytest.fixture
+def stub_interaction(fake_message):
+    return StubInteraction(fake_message)
+
+
+@pytest.fixture
+async def confirm_add_tracks_view(stub_user, fake_player, youtube_playlist):
+    return ConfirmAddTracks(stub_user, fake_player, youtube_playlist)
+
+
+@pytest.fixture
+async def select_track_view(stub_user, fake_player, youtube_playlist):
+    return SelectTrack(stub_user, fake_player, Queue(), youtube_playlist)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -65,15 +65,21 @@ class FakeContext:
     """Fake discord.py context for testing modules that interact with the text chat."""
 
     messages: list[str]
-    files: list[Optional[str]]
     tts: list[bool]
+    files: list[Optional[str]]
+    delete_after: list[float]
+    views: list[object]
 
     voice_client: FakeVoiceClient
 
-    async def send(self, content, *, tts=False, file=None):
+    async def send(
+        self, content, *, tts=False, file=None, delete_after=None, view=None
+    ):
         self.messages.append(content)
-        self.files.append(file)
         self.tts.append(tts)
+        self.files.append(file)
+        self.delete_after.append(delete_after)
+        self.views.append(view)
 
 
 @pytest.fixture
@@ -187,7 +193,7 @@ def fake_voice_client(stub_channel):
 
 @pytest.fixture
 def fake_ctx(fake_voice_client):
-    return FakeContext([], [], [], fake_voice_client)
+    return FakeContext([], [], [], [], [], fake_voice_client)
 
 
 @pytest.fixture

--- a/test/test_music_extractor.py
+++ b/test/test_music_extractor.py
@@ -1,4 +1,4 @@
-from acme_bot.music import add_expire_time
+from acme_bot.music.extractor import add_expire_time
 
 
 def test_add_expire_time_with_youtube_query(youtube_entry_query):

--- a/test/test_music_player.py
+++ b/test/test_music_player.py
@@ -1,7 +1,7 @@
 import pytest
 from discord.ext import commands
 
-from acme_bot.music import PlayerState
+from acme_bot.music.player import PlayerState
 
 
 def test_access_code_returns_passed_value(player):

--- a/test/test_music_queue.py
+++ b/test/test_music_queue.py
@@ -53,13 +53,13 @@ def test_should_stop_with_loop_off(queue_with_tracks):
     assert queue_with_tracks._should_stop(1) is True
 
 
-def test_split_view_with_empty_queue(queue):
-    assert queue.split_view() == ([], [], 0)
+def test_get_tracks_with_empty_queue(queue):
+    assert queue.get_tracks() == ([], [])
 
 
-def test_split_view_with_second_track(queue_with_tracks):
+def test_get_tracks_with_second_track(queue_with_tracks):
     queue_with_tracks._next(1)
-    assert queue_with_tracks.split_view() == (["two"], ["one"], 1)
+    assert queue_with_tracks.get_tracks() == (["two"], ["one"])
 
 
 def test_clear_removes_tracks(queue_with_tracks):
@@ -76,21 +76,21 @@ def test_next_advances_the_queue(queue_with_tracks):
     result = queue_with_tracks._next(1)
 
     assert queue_with_tracks.current == result == "two"
-    assert queue_with_tracks.split_view()[1]
+    assert queue_with_tracks.get_tracks()[1]
 
 
 def test_next_with_negative_offset_returns(queue_with_tracks):
     result = queue_with_tracks._next(-1)
 
     assert queue_with_tracks.current == result == "two"
-    assert queue_with_tracks.split_view()[1]
+    assert queue_with_tracks.get_tracks()[1]
 
 
 def test_next_with_overflow_offset_returns(queue_with_tracks):
     result = queue_with_tracks._next(201)
 
     assert queue_with_tracks.current == result == "two"
-    assert queue_with_tracks.split_view()[1]
+    assert queue_with_tracks.get_tracks()[1]
 
 
 def test_pop_with_empty_queue_throws(queue):

--- a/test/test_music_ui.py
+++ b/test/test_music_ui.py
@@ -1,0 +1,104 @@
+from acme_bot.music.player import PlayerState
+
+
+async def test_confirm_add_has_add_and_cancel_buttons(confirm_add_tracks_view):
+    assert [b.label for b in confirm_add_tracks_view._children] == [
+        "Add to queue",
+        "Cancel",
+    ]
+
+
+async def test_confirm_add_adds_to_queue(
+    confirm_add_tracks_view,
+    fake_player,
+    youtube_playlist,
+    stub_interaction,
+    fake_message,
+):
+    await confirm_add_tracks_view.add_to_queue.callback(stub_interaction)
+
+    assert fake_message.view is None
+    assert fake_player.get_tracks() == (youtube_playlist, [])
+    assert fake_player.state == PlayerState.PLAYING
+    assert fake_player.playing == youtube_playlist[0]
+
+
+async def test_confirm_add_to_nonempty_queue(
+    confirm_add_tracks_view,
+    fake_player,
+    youtube_playlist,
+    stub_interaction,
+    fake_message,
+):
+    track = youtube_playlist[1]
+    fake_player.append(track)
+    await fake_player.start_player(track)
+    await confirm_add_tracks_view.add_to_queue.callback(stub_interaction)
+
+    assert fake_message.view is None
+    assert fake_player.get_tracks() == ([track] + youtube_playlist, [])
+    assert fake_player.state == PlayerState.PLAYING
+    assert fake_player.playing == track
+
+
+async def test_confirm_add_cancels(
+    confirm_add_tracks_view,
+    fake_player,
+    youtube_playlist,
+    stub_interaction,
+    fake_message,
+):
+    await confirm_add_tracks_view.cancel.callback(stub_interaction)
+
+    assert fake_message.view is None
+    assert fake_player.get_tracks() == ([], [])
+    assert fake_player.state == PlayerState.IDLE
+
+
+async def test_select_has_track_and_cancel_buttons(select_track_view):
+    assert [b.label for b in select_track_view._children] == ["1", "2", "Cancel"]
+
+
+async def test_select_adds_to_queue(
+    select_track_view,
+    fake_player,
+    youtube_playlist,
+    stub_interaction,
+    fake_message,
+):
+    await select_track_view._children[1].callback(stub_interaction)
+    track = youtube_playlist[1]
+
+    assert fake_message.view is None
+    assert fake_player.get_tracks() == ([track], [])
+    assert fake_player.state == PlayerState.PLAYING
+    assert fake_player.playing == track
+
+
+async def test_select_to_nonempty_queue(
+    select_track_view,
+    fake_player,
+    youtube_playlist,
+    stub_interaction,
+    fake_message,
+):
+    track = youtube_playlist[1]
+    fake_player.append(track)
+    await fake_player.start_player(track)
+    await select_track_view._children[0].callback(stub_interaction)
+    new = youtube_playlist[0]
+
+    assert fake_message.view is None
+    assert fake_player.get_tracks() == ([track, new], [])
+    assert fake_player.state == PlayerState.PLAYING
+    assert fake_player.playing == track
+
+
+async def test_select_cancels(
+    select_track_view, player, youtube_playlist, stub_interaction, fake_message
+):
+    await select_track_view._children[-1].callback(stub_interaction)
+
+    assert fake_message.view is None
+    assert player.get_tracks() == ([], [])
+    assert player.state == PlayerState.IDLE

--- a/test/test_textutils.py
+++ b/test/test_textutils.py
@@ -1,4 +1,6 @@
-from itertools import cycle, islice, repeat
+from itertools import cycle, islice
+
+from discord.ui import View
 
 from acme_bot.textutils import escape_md_block, send_pages
 
@@ -21,7 +23,7 @@ async def test_send_pages_long_multiline_split_into_multiple_messages(fake_ctx):
     long = "much much longer\n" * 4
 
     await send_pages(fake_ctx, long, max_length=20)
-    assert fake_ctx.messages == list(islice(repeat("much much longer"), 4))
+    assert fake_ctx.messages == ["much much longer"] * 4
 
 
 async def test_send_pages_preserves_empty_lines(fake_ctx):
@@ -52,6 +54,15 @@ async def test_send_pages_escapes_markdown_blocks_in_content(fake_ctx):
 
     await send_pages(fake_ctx, content, escape_md_blocks=True)
     assert "```" not in fake_ctx.messages[0]
+
+
+async def test_send_pages_sends_view_in_last_chunk(fake_ctx):
+    long = "much much longer\n" * 4
+    view = View()
+
+    await send_pages(fake_ctx, long, max_length=20, view=view)
+    assert fake_ctx.views[:3] == [None] * 3
+    assert fake_ctx.views[3] == view
 
 
 def test_escape_md_block_preserves_non_block_code():

--- a/test/test_textutils.py
+++ b/test/test_textutils.py
@@ -65,6 +65,14 @@ async def test_send_pages_sends_view_in_last_chunk(fake_ctx):
     assert fake_ctx.views[3] == view
 
 
+async def test_send_pages_accepts_message_reference(fake_ctx):
+    long = "much much longer\n" * 4
+    message = {}
+
+    await send_pages(fake_ctx, long, max_length=20, reference=message)
+    assert fake_ctx.references == [message] * 4
+
+
 def test_escape_md_block_preserves_non_block_code():
     with_code = "foo `code section` bar"
     assert escape_md_block(with_code) == with_code


### PR DESCRIPTION
* `current` and `queue` now use compact embeds
* `play`, `play-snd` and `play-url` now use buttons to add/select/cancel
* `ctx.send_pages` now accepts delete_after, view and reference parameters
* Added unit tests for music.ui module
* Improved comments