### PR TITLE
Refactor ShellModule

### DIFF
--- a/acme_bot/__init__.py
+++ b/acme_bot/__init__.py
@@ -29,7 +29,7 @@ from textx.exceptions import TextXSyntaxError
 from acme_bot.autoloader import get_autoloaded_cogs
 from acme_bot.config import load_config
 from acme_bot.config.properties import DISCORD_TOKEN, COMMAND_PREFIX, LOG_LEVEL
-from acme_bot.shell import ShellModule
+from acme_bot.shell.interpreter import META_MODEL
 from acme_bot.textutils import send_pages
 
 log = logging.getLogger(__name__)
@@ -135,7 +135,7 @@ def run():
             message = ctx.message.content
             command = message.removeprefix(ctx.prefix)
             try:
-                model = ShellModule.META_MODEL.model_from_str(command.strip())
+                model = META_MODEL.model_from_str(command.strip())
                 await model.eval(ctx)
             except (
                 commands.CommandError,  # Command validation errors

--- a/acme_bot/__init__.py
+++ b/acme_bot/__init__.py
@@ -116,19 +116,7 @@ def run():
                 f"For more information, refer to `{ctx.prefix}help {cmd.name}`."
             )
         else:
-            await ctx.send(f"Error: {error}")
-
-    @client.event
-    async def on_disconnect():
-        """Handle the termination of connections to Discord servers."""
-        # client.get_cog("MusicModule").pause_players()
-        log.warning("Connection closed, will attempt to reconnect")
-
-    @client.event
-    async def on_resumed():
-        """Handle restarts of connections to Discord servers."""
-        # client.get_cog("MusicModule").resume_players()
-        log.info("Connection resumed")
+            await ctx.send_pages(f"Error: {error}")
 
     async def eval_command(ctx):
         if ctx.invoked_with:

--- a/acme_bot/__init__.py
+++ b/acme_bot/__init__.py
@@ -59,8 +59,7 @@ class HelpCommand(commands.DefaultHelpCommand):
     # pylint: disable=arguments-differ
     async def command_callback(self, ctx, command=None):
         # Defining this attribute is necessary for the help command to work
-        # pylint: disable=attribute-defined-outside-init
-        self.context = ctx
+        self.context = ctx  # pylint: disable=attribute-defined-outside-init
         return await super().command_callback(ctx, command=command)
 
 
@@ -105,12 +104,12 @@ def run():
     async def on_command_error(ctx, error):
         """Handle exceptions raised during command execution."""
         if isinstance(error, commands.CommandError) and hasattr(error, "original"):
-            await ctx.send(f"Error: {error.original}")
+            await ctx.send_pages(f"Error: {error.original}")
         elif isinstance(error, TextXSyntaxError):
-            await ctx.send(f"Syntax error: {error.message}")
-        elif isinstance(error, TypeError):
+            await ctx.send_pages(f"Syntax error: {error.message}")
+        elif isinstance(error, (TypeError, ValueError)):
             cmd = ctx.command
-            await ctx.send(
+            await ctx.send_pages(
                 f"Error: {error}\n"
                 f"Command usage: `{ctx.prefix}{cmd.qualified_name} {cmd.signature}`\n"
                 f"For more information, refer to `{ctx.prefix}help {cmd.name}`."
@@ -132,8 +131,7 @@ def run():
             ) as exc:
                 client.dispatch("command_error", ctx, exc)
             # Log the unhandled exceptions for later analysis
-            # pylint: disable=broad-except
-            except Exception as error:
+            except Exception as error:  # pylint: disable=broad-except
                 log.exception(
                     "Unhandled exception caused by message '%s':",
                     ctx.message.content,

--- a/acme_bot/convutils.py
+++ b/acme_bot/convutils.py
@@ -1,0 +1,26 @@
+"""Data conversion functions used by shell commands."""
+#  Copyright (C) 2023  Krzysztof Molski
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from discord.ext import commands
+
+
+def to_int(value):
+    """Convert a shell value (str, int, bool or None) to an integer."""
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise commands.CommandError(f"Invalid integer: {value}") from exc

--- a/acme_bot/shell/__init__.py
+++ b/acme_bot/shell/__init__.py
@@ -76,21 +76,6 @@ async def execute_system_cmd(name, *args, stdin=None):
 class ShellModule(commands.Cog, CogFactory):
     """Shell utility commands."""
 
-    META_MODEL = metamodel_from_file(
-        join(dirname(__file__), "grammar.tx"),
-        classes=[
-            ExprSeq,
-            ExprComp,
-            Command,
-            StrLiteral,
-            IntLiteral,
-            BoolLiteral,
-            FileContent,
-            ExprSubst,
-        ],
-        use_regexp_group=True,
-    )
-
     __GREP_ARGS = re.compile(r"-[0-9ABCEFGiovwx]+")
 
     @classmethod

--- a/acme_bot/shell/__init__.py
+++ b/acme_bot/shell/__init__.py
@@ -200,7 +200,7 @@ class ShellModule(commands.Cog, CogFactory):
         opts = [str(option) for option in opts]
         validate_options(opts, self.__GREP_ARGS)
         # Filter out empty lines that produce all-matching patterns.
-        patterns = "\n".join(p for p in patterns.split("\n") if p)
+        patterns = "\n".join(p for p in patterns.splitlines() if p)
 
         output = trim_double_newline(
             await execute_system_cmd(

--- a/acme_bot/shell/__init__.py
+++ b/acme_bot/shell/__init__.py
@@ -110,7 +110,7 @@ class ShellModule(commands.Cog, CogFactory):
         """
         content = "".join(str(arg) for arg in arguments)
         if ctx.display:
-            await ctx.send_pages(content)
+            await ctx.send_pages(content, fmt=MD_BLOCK_FMT, escape_md_blocks=True)
         return content
 
     @commands.command()
@@ -224,7 +224,7 @@ class ShellModule(commands.Cog, CogFactory):
         )
 
         if ctx.display:
-            await ctx.send_pages(output, fmt=__MD_BLOCK_FMT, escape_md_blocks=True)
+            await ctx.send_pages(output, fmt=MD_BLOCK_FMT, escape_md_blocks=True)
 
         return output
 
@@ -268,7 +268,7 @@ class ShellModule(commands.Cog, CogFactory):
         output = "\n".join(lines)
 
         if ctx.display:
-            await ctx.send_pages(output, fmt=__MD_BLOCK_FMT, escape_md_blocks=True)
+            await ctx.send_pages(output, fmt=MD_BLOCK_FMT, escape_md_blocks=True)
 
         return output
 
@@ -290,7 +290,7 @@ class ShellModule(commands.Cog, CogFactory):
         output = "\n".join(lines)
 
         if ctx.display:
-            await ctx.send_pages(output, fmt=__MD_BLOCK_FMT, escape_md_blocks=True)
+            await ctx.send_pages(output, fmt=MD_BLOCK_FMT, escape_md_blocks=True)
 
         return output
 
@@ -330,7 +330,7 @@ class ShellModule(commands.Cog, CogFactory):
         count = len(data)
 
         if ctx.display:
-            await ctx.send_pages(f"```\n{count}\n```")
+            await ctx.send_pages(str(count), fmt=MD_BLOCK_FMT)
 
         return count
 
@@ -353,7 +353,7 @@ class ShellModule(commands.Cog, CogFactory):
         )
 
         if ctx.display:
-            await ctx.send_pages(output, fmt=__MD_BLOCK_FMT, escape_md_blocks=True)
+            await ctx.send_pages(output, fmt=MD_BLOCK_FMT, escape_md_blocks=True)
 
         return output
 
@@ -372,7 +372,7 @@ class ShellModule(commands.Cog, CogFactory):
         output = "\n".join(sorted(lines))
 
         if ctx.display:
-            await ctx.send_pages(output, fmt=__MD_BLOCK_FMT, escape_md_blocks=True)
+            await ctx.send_pages(output, fmt=MD_BLOCK_FMT, escape_md_blocks=True)
 
         return output
 
@@ -391,7 +391,7 @@ class ShellModule(commands.Cog, CogFactory):
         output = "\n".join(line for line, _ in groupby(lines))
 
         if ctx.display:
-            await ctx.send_pages(output, fmt=__MD_BLOCK_FMT, escape_md_blocks=True)
+            await ctx.send_pages(output, fmt=MD_BLOCK_FMT, escape_md_blocks=True)
 
         return output
 
@@ -411,6 +411,6 @@ class ShellModule(commands.Cog, CogFactory):
         output = "\n".join(lines)
 
         if ctx.display:
-            await ctx.send_pages(output, fmt=__MD_BLOCK_FMT, escape_md_blocks=True)
+            await ctx.send_pages(output, fmt=MD_BLOCK_FMT, escape_md_blocks=True)
 
         return output

--- a/acme_bot/shell/interpreter.py
+++ b/acme_bot/shell/interpreter.py
@@ -30,6 +30,9 @@ class ExprSeq:
         self.parent = parent
         self.expr_comps = expr_comps
 
+    def __eq__(self, other):
+        return self.expr_comps == other.expr_comps
+
     async def eval(self, ctx):
         """Evaluate an expression sequence by evaluating its components and
         concatenating their return values."""
@@ -47,6 +50,9 @@ class ExprComp:
     def __init__(self, parent, exprs):
         self.parent = parent
         self.exprs = exprs
+
+    def __eq__(self, other):
+        return self.exprs == other.exprs
 
     async def eval(self, ctx):
         """Evaluate an expression composition by evaluating the components and
@@ -75,12 +81,15 @@ class Command:
         self.name = name
         self.args = args
 
+    def __eq__(self, other):
+        return self.name == other.name and self.args == other.args
+
     async def eval(self, ctx, pipe):
         """Execute a command by evaluating its arguments, and calling its callback
         using the data piped in from the previous expression."""
         cmd = ctx.bot.get_command(self.name)
         if cmd is None:
-            raise commands.CommandError(f"Command '{self.name}' not found")
+            raise commands.CommandError(f"Command `{self.name}` not found")
 
         ctx.command = cmd
         if not await cmd.can_run(ctx):
@@ -108,6 +117,9 @@ class StrLiteral:
         self.parent = parent
         self.value = value
 
+    def __eq__(self, other):
+        return self.value == other.value
+
     async def eval(self, ctx, *_, **__):
         """Evaluate the string literal, printing it in a code block if necessary."""
         if ctx.display:
@@ -122,6 +134,9 @@ class IntLiteral:
         self.parent = parent
         self.value = value
 
+    def __eq__(self, other):
+        return self.value == other.value
+
     async def eval(self, *_, **__):
         """Evaluate the integer literal."""
         return self.value
@@ -134,6 +149,9 @@ class BoolLiteral:
         self.parent = parent
         self.value = value.lower() in ("yes", "true", "enable", "on")
 
+    def __eq__(self, other):
+        return self.value == other.value
+
     async def eval(self, *_, **__):
         """Evaluate the boolean literal."""
         return self.value
@@ -145,6 +163,9 @@ class FileContent:
     def __init__(self, parent, name):
         self.parent = parent
         self.name = name
+
+    def __eq__(self, other):
+        return self.name == other.name
 
     async def eval(self, ctx, *_, **__):
         """Extract the file contents."""
@@ -167,6 +188,9 @@ class ExprSubst:
     def __init__(self, parent, expr_seq):
         self.parent = parent
         self.expr_seq = expr_seq
+
+    def __eq__(self, other):
+        return self.expr_seq == other.expr_seq
 
     async def eval(self, ctx, *_, **__):
         """Evaluate the expression sequence in the substitution."""

--- a/acme_bot/shell/interpreter.py
+++ b/acme_bot/shell/interpreter.py
@@ -36,12 +36,12 @@ class ExprSeq:
     async def eval(self, ctx):
         """Evaluate an expression sequence by evaluating its components and
         concatenating their return values."""
-        result = ""
+        results = []
         for elem in self.expr_comps:
             ret = await elem.eval(ctx)
             if ret is not None:
-                result += str(ret)
-        return result
+                results += str(ret)
+        return "".join(results)
 
 
 class ExprComp:
@@ -58,7 +58,7 @@ class ExprComp:
         """Evaluate an expression composition by evaluating the components and
         passing the return value of the previous expression to the input of the
         following commands."""
-        data, result = None, ""
+        data, result = None, None
         for index, elem in enumerate(self.exprs, start=1):
             # Display should only be enabled for the last expression in sequence.
             temp_ctx = copy(ctx)
@@ -178,8 +178,7 @@ class FileContent:
                             content, fmt=MD_BLOCK_FMT, escape_md_blocks=True
                         )
                     return content
-
-        raise commands.CommandError("No such file!")
+        raise commands.CommandError(f"File `{self.name}` not found")
 
 
 class ExprSubst:

--- a/acme_bot/shell/interpreter.py
+++ b/acme_bot/shell/interpreter.py
@@ -1,0 +1,190 @@
+"""Shell interpreter based on the TextX parser generator."""
+#  Copyright (C) 2019-2023  Krzysztof Molski
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from copy import copy
+from os.path import join, dirname
+
+from discord.ext import commands
+from textx import metamodel_from_file
+
+from acme_bot.textutils import MD_BLOCK_FMT
+
+
+class ExprSeq:
+    """This class represents expression sequences for use in the TextX metamodel."""
+
+    def __init__(self, parent=None, expr_comps=None):
+        self.parent = parent
+        self.expr_comps = expr_comps
+
+    async def eval(self, ctx):
+        """Evaluate an expression sequence by evaluating its components and
+        concatenating their return values."""
+        result = ""
+        for elem in self.expr_comps:
+            ret = await elem.eval(ctx)
+            if ret is not None:
+                result += str(ret)
+        return result
+
+
+class ExprComp:
+    """This class represents expression compositions for use in the TextX metamodel."""
+
+    def __init__(self, parent, exprs):
+        self.parent = parent
+        self.exprs = exprs
+
+    async def eval(self, ctx):
+        """Evaluate an expression composition by evaluating the components and
+        passing the return value of the previous expression to the input of the
+        following commands."""
+        data, result = None, ""
+        for index, elem in enumerate(self.exprs, start=1):
+            # Display should only be enabled for the last expression in sequence.
+            temp_ctx = copy(ctx)
+            temp_ctx.display = ctx.display and (index == len(self.exprs))
+            try:
+                result = await elem.eval(temp_ctx, data)
+            except (commands.CommandError, TypeError):
+                # To report errors correctly, save the command throwing the exception.
+                ctx.command = temp_ctx.command
+                raise
+            data = result
+        return result
+
+
+class Command:
+    """This class represents the bot's commands for use in the TextX metamodel."""
+
+    def __init__(self, parent, name, args):
+        self.parent = parent
+        self.name = name
+        self.args = args
+
+    async def eval(self, ctx, pipe):
+        """Execute a command by evaluating its arguments, and calling its callback
+        using the data piped in from the previous expression."""
+        cmd = ctx.bot.get_command(self.name)
+        if cmd is None:
+            raise commands.CommandError(f"Command '{self.name}' not found")
+
+        ctx.command = cmd
+        if not await cmd.can_run(ctx):
+            raise commands.CommandError(f"Checks for {cmd.qualified_name} failed")
+        await cmd.call_before_hooks(ctx)
+
+        # Argument evaluation should not print outputs.
+        temp_ctx = copy(ctx)
+        temp_ctx.display = False
+        args = (
+            ([ctx] if cmd.cog is None else [cmd.cog, ctx])
+            + ([pipe] if pipe is not None else [])
+            + ([await elem.eval(temp_ctx) for elem in self.args])
+        )
+        result = await cmd.callback(*args)
+
+        await cmd.call_after_hooks(ctx)
+        return result
+
+
+class StrLiteral:
+    """This class represents string literals for use in the TextX metamodel."""
+
+    def __init__(self, parent, value):
+        self.parent = parent
+        self.value = value
+
+    async def eval(self, ctx, *_, **__):
+        """Evaluate the string literal, printing it in a code block if necessary."""
+        if ctx.display:
+            await ctx.send_pages(self.value, fmt=MD_BLOCK_FMT, escape_md_blocks=True)
+        return self.value
+
+
+class IntLiteral:
+    """This class represents integer literals for use in the TextX metamodel."""
+
+    def __init__(self, parent, value):
+        self.parent = parent
+        self.value = value
+
+    async def eval(self, *_, **__):
+        """Evaluate the integer literal."""
+        return self.value
+
+
+class BoolLiteral:
+    """This class represents boolean literals for use in the TextX metamodel."""
+
+    def __init__(self, parent, value):
+        self.parent = parent
+        self.value = value.lower() in ("yes", "true", "enable", "on")
+
+    async def eval(self, *_, **__):
+        """Evaluate the boolean literal."""
+        return self.value
+
+
+class FileContent:
+    """This class represents file contents for use in the TextX metamodel."""
+
+    def __init__(self, parent, name):
+        self.parent = parent
+        self.name = name
+
+    async def eval(self, ctx, *_, **__):
+        """Extract the file contents."""
+        async for msg in ctx.history(limit=1000):
+            for elem in msg.attachments:
+                if elem.filename == self.name:
+                    content = str(await elem.read(), errors="replace")
+                    if ctx.display:
+                        await ctx.send_pages(
+                            content, fmt=MD_BLOCK_FMT, escape_md_blocks=True
+                        )
+                    return content
+
+        raise commands.CommandError("No such file!")
+
+
+class ExprSubst:
+    """This class represents expression substitutions for use in the TextX metamodel."""
+
+    def __init__(self, parent, expr_seq):
+        self.parent = parent
+        self.expr_seq = expr_seq
+
+    async def eval(self, ctx, *_, **__):
+        """Evaluate the expression sequence in the substitution."""
+        result = await self.expr_seq.eval(ctx)
+        return result
+
+
+META_MODEL = metamodel_from_file(
+    join(dirname(__file__), "grammar.tx"),
+    classes=[
+        ExprSeq,
+        ExprComp,
+        Command,
+        StrLiteral,
+        IntLiteral,
+        BoolLiteral,
+        FileContent,
+        ExprSubst,
+    ],
+    use_regexp_group=True,
+)

--- a/acme_bot/textutils.py
+++ b/acme_bot/textutils.py
@@ -21,6 +21,8 @@ from textwrap import wrap
 # According to https://discord.com/developers/docs/resources/channel
 MAX_MESSAGE_LENGTH = 2000
 
+MD_BLOCK_FMT = "```\n{}\n```"
+
 
 def _split_message(text, limit):
     """Split a message into chunks with the specified maximum length.

--- a/poetry.lock
+++ b/poetry.lock
@@ -609,13 +609,13 @@ graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
 name = "discord-py"
-version = "2.3.0"
+version = "2.3.1"
 description = "A Python wrapper for the Discord API"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "discord.py-2.3.0-py3-none-any.whl", hash = "sha256:3e9498967822ad4499f8f72deb9173f942d9827d92b6e4e4e7732d24f78f300c"},
-    {file = "discord.py-2.3.0.tar.gz", hash = "sha256:c71066a30f037d069218e59092505c3e8945fd175e396a80748056d989756806"},
+    {file = "discord.py-2.3.1-py3-none-any.whl", hash = "sha256:149652f24da299706270bf8c03c2fcf80cf1caf3a480744c61d5b001688b380d"},
+    {file = "discord.py-2.3.1.tar.gz", hash = "sha256:8eb4fe66b5d503da6de3a8425e23012711dc2fbcd7a782107a92beac15ee3459"},
 ]
 
 [package.dependencies]
@@ -1516,4 +1516,4 @@ websockets = "*"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "2c60a6ec5b976955e19673ae4b7fcbe3c3abde643b5552d053a40f3f727fc61e"
+content-hash = "fc12407321cf6a1cc36febd7d514053afa78dfcfee55a0a214286104f9a824bf"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "aio-pika"
-version = "9.1.2"
+version = "9.1.3"
 description = "Wrapper around the aiormq for asyncio and humans"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "aio_pika-9.1.2-py3-none-any.whl", hash = "sha256:d109bafa360369315dc083098cf6597dea6d99d3f25cf07da2a0f00ec294ab1b"},
-    {file = "aio_pika-9.1.2.tar.gz", hash = "sha256:bacec2aea65b0ca9011400db45568340fae9022f8ae27a8fee8df42889127738"},
+    {file = "aio_pika-9.1.3-py3-none-any.whl", hash = "sha256:32fd2da24cb81ef8f08503bb9a3a1537bbf54a565b7a4fb5f6bb4f93fa5113a4"},
+    {file = "aio_pika-9.1.3.tar.gz", hash = "sha256:05b979dd12ac1728a560884aa5676d8ea158afb9b3b14951ff99b9a3b01a8ae1"},
 ]
 
 [package.dependencies]
@@ -1516,4 +1516,4 @@ websockets = "*"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "c560191c7069990bb4aa90f972d59e61a57f7c2909da896a0b957a201262f30c"
+content-hash = "610f21401bb4c85cb3ffe278473fccfecafa001da55968a115cb14b5d2479ecc"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1140,13 +1140,13 @@ tests = ["hypothesis (>=3.27.0)", "pytest (>=3.2.1,!=3.3.0)"]
 
 [[package]]
 name = "pytest"
-version = "7.3.2"
+version = "7.4.0"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.3.2-py3-none-any.whl", hash = "sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295"},
-    {file = "pytest-7.3.2.tar.gz", hash = "sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b"},
+    {file = "pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
+    {file = "pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
 ]
 
 [package.dependencies]
@@ -1516,4 +1516,4 @@ websockets = "*"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "610f21401bb4c85cb3ffe278473fccfecafa001da55968a115cb14b5d2479ecc"
+content-hash = "2c60a6ec5b976955e19673ae4b7fcbe3c3abde643b5552d053a40f3f727fc61e"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1496,13 +1496,13 @@ multidict = ">=4.0"
 
 [[package]]
 name = "yt-dlp"
-version = "2023.3.4"
+version = "2023.7.6"
 description = "A youtube-dl fork with additional features and patches"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "yt-dlp-2023.3.4.tar.gz", hash = "sha256:265d5da97a76c15d7d9a4088a67b78acd5dcf6f8cfd8257c52f581ff996ff515"},
-    {file = "yt_dlp-2023.3.4-py2.py3-none-any.whl", hash = "sha256:40ca421407ce07c8fd700854fd978d58526ec6fff3468caa34ff1c7333b8dc34"},
+    {file = "yt-dlp-2023.7.6.tar.gz", hash = "sha256:cb58373869c8ccb5034746f91cfccd6d25ea697090dfd6f93e9034d51eb4aed2"},
+    {file = "yt_dlp-2023.7.6-py2.py3-none-any.whl", hash = "sha256:b33b3f68751f33dd8290f1f61f7a011679b3b512aa223df3bff496688bc0bd19"},
 ]
 
 [package.dependencies]
@@ -1516,4 +1516,4 @@ websockets = "*"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "fc12407321cf6a1cc36febd7d514053afa78dfcfee55a0a214286104f9a824bf"
+content-hash = "36a099da0669772e500c3b844e772045d0b4ca272bf5b8f5af25cbbc749bbc8d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "acme-bot"
-version = "0.6.0-dev"
+version = "1.0.0-dev"
 description = "Discord music bot with a custom shell language"
 license = "AGPL-3.0-or-later"
 authors = ["kmolski <krzysztof.molski29@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ include = ["acme_bot/version_info/commit.txt"]
 [tool.poetry.dependencies]
 python = "^3.9"
 aio-pika = "^9.1.3"
-"discord.py" = {version = "^2.3.0", extras = ["voice"]}
+"discord.py" = {version = "^2.3.1", extras = ["voice"]}
 python-dotenv = "^1.0.0"
 textX = "^3.1.1"
 yt-dlp = "^2023.3.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ textX = "^3.1.1"
 yt-dlp = "^2023.3.4"
 
 [tool.poetry.group.test.dependencies]
-pytest = "^7.3.2"
+pytest = "^7.4.0"
 pytest-asyncio = "^0.21.0"
 
 [tool.poetry.group.lint.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ aio-pika = "^9.1.3"
 "discord.py" = {version = "^2.3.1", extras = ["voice"]}
 python-dotenv = "^1.0.0"
 textX = "^3.1.1"
-yt-dlp = "^2023.3.4"
+yt-dlp = "^2023.7.6"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = ["acme_bot/version_info/commit.txt"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-aio-pika = "^9.1.2"
+aio-pika = "^9.1.3"
 "discord.py" = {version = "^2.3.0", extras = ["voice"]}
 python-dotenv = "^1.0.0"
 textX = "^3.1.1"

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -1,0 +1,26 @@
+import re
+
+import pytest
+from discord.ext import commands
+
+from acme_bot.shell import validate_options, trim_double_newline, execute_system_cmd
+
+
+def test_validate_options_passes_on_valid_opt():
+    regex = re.compile(r"-[ABC]+")
+    validate_options(["-ABC"], regex)
+
+
+def test_validate_options_throws_on_invalid_opt():
+    regex = re.compile(r"-[ABC]+")
+    with pytest.raises(commands.CommandError):
+        validate_options(["-DEF"], regex)
+
+
+def test_trim_double_newline_with_single_newline():
+    string = "foo\n"
+    assert trim_double_newline(string) == string
+
+
+def test_trim_double_newline_with_double_newline():
+    assert trim_double_newline("foo\n\n") == "foo\n"

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -3,7 +3,7 @@ import re
 import pytest
 from discord.ext import commands
 
-from acme_bot.shell import validate_options, trim_double_newline, execute_system_cmd
+from acme_bot.shell import validate_options, trim_double_newline
 
 
 def test_validate_options_passes_on_valid_opt():
@@ -24,3 +24,82 @@ def test_trim_double_newline_with_single_newline():
 
 def test_trim_double_newline_with_double_newline():
     assert trim_double_newline("foo\n\n") == "foo\n"
+
+
+async def test_concat_joins_arguments(fake_ctx, shell_module):
+    assert await shell_module.concat(None, fake_ctx, False, 1) == "False1"
+    assert fake_ctx.messages[0] == "```\nFalse1\n```"
+
+
+async def test_ping_adds_reaction(fake_ctx, shell_module):
+    assert await shell_module.ping(None, fake_ctx) >= "10"
+    assert "\U0001F3D3" in fake_ctx.message.reactions
+
+
+async def test_print_displays_the_content(fake_ctx, shell_module):
+    assert await shell_module.print(None, fake_ctx, "foo", "python") == "foo"
+    assert fake_ctx.messages[0] == "```python\nfoo\n```"
+
+
+async def test_to_file_writes_the_file(fake_ctx, shell_module):
+    assert await shell_module.to_file(None, fake_ctx, "foo", "filename") == "foo"
+    assert "filename" in fake_ctx.messages[0]
+    assert "foo" in fake_ctx.files[0].fp
+
+
+async def test_tail_returns_the_last_lines(fake_ctx, shell_module):
+    assert await shell_module.tail(None, fake_ctx, "foo\nbar\nbaz", 2) == "bar\nbaz"
+    assert fake_ctx.messages[0] == "```\nbar\nbaz\n```"
+
+
+async def test_tail_throws_with_zero(fake_ctx, shell_module):
+    with pytest.raises(commands.CommandError):
+        await shell_module.tail(None, fake_ctx, "foo\nbar\nbaz", 0)
+
+
+async def test_head_returns_the_first_lines(fake_ctx, shell_module):
+    assert await shell_module.head(None, fake_ctx, "foo\nbar\nbaz", 2) == "foo\nbar"
+    assert fake_ctx.messages[0] == "```\nfoo\nbar\n```"
+
+
+async def test_head_throws_with_zero(fake_ctx, shell_module):
+    with pytest.raises(commands.CommandError):
+        await shell_module.head(None, fake_ctx, "foo\nbar\nbaz", 0)
+
+
+async def test_lines_returns_the_line_range(fake_ctx, shell_module):
+    assert await shell_module.lines(None, fake_ctx, "foo\nbar\nbaz", 1, 2) == "foo\nbar"
+    assert fake_ctx.messages[0] == "```\nfoo\nbar\n```"
+
+
+async def test_lines_throws_with_negative_start(fake_ctx, shell_module):
+    with pytest.raises(commands.CommandError):
+        await shell_module.lines(shell_module, fake_ctx, "foo\nbar\nbaz", -10, 1)
+
+
+async def test_lines_throws_when_start_is_greater_than_end(fake_ctx, shell_module):
+    with pytest.raises(commands.CommandError):
+        await shell_module.lines(shell_module, fake_ctx, "foo\nbar\nbaz", 2, 1)
+
+
+async def test_count_returns_the_number_of_lines(fake_ctx, shell_module):
+    assert await shell_module.count(None, fake_ctx, "foo\nbar\nbaz") == 3
+    assert fake_ctx.messages[0] == "```\n3\n```"
+
+
+async def test_enumerate_returns_the_numbered_lines(fake_ctx, shell_module):
+    assert (
+        await shell_module.enumerate(None, fake_ctx, "foo\nbar\nbaz")
+        == "1  foo\n2  bar\n3  baz"
+    )
+    assert fake_ctx.messages[0] == "```\n1  foo\n2  bar\n3  baz\n```"
+
+
+async def test_sort_returns_the_sorted_lines(fake_ctx, shell_module):
+    assert await shell_module.sort(None, fake_ctx, "foo\nbar\nbaz") == "bar\nbaz\nfoo"
+    assert fake_ctx.messages[0] == "```\nbar\nbaz\nfoo\n```"
+
+
+async def test_unique_returns_the_unique_lines(fake_ctx, shell_module):
+    assert await shell_module.unique(None, fake_ctx, "foo\nfoo\nfoo\nbar") == "foo\nbar"
+    assert fake_ctx.messages[0] == "```\nfoo\nbar\n```"

--- a/test/test_shell_interpreter.py
+++ b/test/test_shell_interpreter.py
@@ -1,0 +1,26 @@
+from acme_bot.shell.interpreter import (
+    META_MODEL,
+    ExprSeq,
+    ExprComp,
+    Command,
+    StrLiteral,
+)
+
+
+def test_parse_simple_command():
+    expected = ExprSeq(
+        parent=None,
+        expr_comps=[
+            ExprComp(
+                None,
+                exprs=[
+                    Command(
+                        None,
+                        name="echo",
+                        args=[StrLiteral(None, value=s) for s in ["hello", "world"]],
+                    ),
+                ],
+            ),
+        ],
+    )
+    assert META_MODEL.model_from_str("echo hello world") == expected


### PR DESCRIPTION
- Extracted the parser & AST classes into the `acme_bot.shell.interpreter` module
- Added unit tests for shell module commands & parser
- Removed on_disconnect and on_resumed handlers
- Created `to_int` converter for integer arguments
- Concat command now uses markdown blocks for display
- Simplified `lines` command
- Optimized ExprSeq evaluation