### PR TITLE
Refactor MusicModule

### DIFF
--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -44,22 +44,19 @@ def display_entry(entry):
 
 def assemble_menu(header, entries):
     """Create a menu with the given header and information about the queue entries."""
-    menu = header
-    for entry in enumerate(entries, start=1):
-        menu += f"\n{display_entry(entry)}"
-    return menu
+    lines = [header] + [display_entry(entry) for entry in enumerate(entries, start=1)]
+    return "\n".join(lines)
 
 
 def export_entry(entry):
     """Export an entry string with the URL, title and duration."""
-    return "{webpage_url}    {title} - {duration_string}".format(**entry)
+    return "{webpage_url}    {title} - {duration_string}\n".format(**entry)
 
 
 def export_entry_list(*iterables):
     """Export entry iterables using export_entry."""
     lines = [export_entry(entry) for entry in chain.from_iterable(iterables)]
-    lines.append("")
-    return "\n".join(lines)
+    return "".join(lines)
 
 
 def strip_urls(urls):
@@ -148,7 +145,7 @@ class MusicModule(commands.Cog, CogFactory):
         """Join the sender's current voice channel."""
         if ctx.display:
             await ctx.send(
-                f"\u27A1 Joining voice channel **{ctx.voice_client.channel.name}**."
+                f"\u27A1\uFE0F Joining channel **{ctx.voice_client.channel.name}**."
             )
 
     @commands.command()
@@ -161,7 +158,7 @@ class MusicModule(commands.Cog, CogFactory):
         """
         if ctx.display:
             await ctx.send(
-                f"\u23CF Quitting voice channel **{ctx.voice_client.channel.name}**."
+                f"\u23CF\uFE0F Quitting channel **{ctx.voice_client.channel.name}**."
             )
         async with self.__lock, self.__get_player(ctx) as player:
             player.stop()
@@ -235,7 +232,7 @@ class MusicModule(commands.Cog, CogFactory):
             results = await self.extractor.get_entries_by_urls(strip_urls(url_list))
 
         await ctx.send(
-            f"\u2705 Extracted {len(results)} tracks.",
+            f"\u2705\uFE0F Extracted {len(results)} tracks.",
             view=ConfirmAddTracks(ctx.author, self.__get_player(ctx), results),
             reference=ctx.message,
         )
@@ -256,7 +253,7 @@ class MusicModule(commands.Cog, CogFactory):
         async with ctx.typing():
             results = await self.extractor.get_entries_by_urls(strip_urls(url_list))
         if ctx.display:
-            await ctx.send(f"\u2705 Extracted {len(results)} tracks.")
+            await ctx.send(f"\u2705\uFE0F Extracted {len(results)} tracks.")
 
         return export_entry_list(results)
 
@@ -309,7 +306,7 @@ class MusicModule(commands.Cog, CogFactory):
         async with self.__get_player(ctx) as player:
             player.pause()
         if ctx.display:
-            await ctx.send("\u23F8 Paused.")
+            await ctx.send("\u23F8\uFE0F Paused.")
 
     @commands.command()
     async def queue(self, ctx):
@@ -353,7 +350,7 @@ class MusicModule(commands.Cog, CogFactory):
             head, tail = player.get_tracks()
             player.clear()
             if ctx.display:
-                await ctx.send("\u2716 Queue cleared.")
+                await ctx.send("\u2716\uFE0F Queue cleared.")
             return export_entry_list(head, tail)
 
     @commands.command()
@@ -362,7 +359,7 @@ class MusicModule(commands.Cog, CogFactory):
         async with self.__get_player(ctx) as player:
             player.stop()
         if ctx.display:
-            await ctx.send("\u23F9 Stopped.")
+            await ctx.send("\u23F9\uFE0F Stopped.")
 
     @commands.command(aliases=["volu"])
     async def volume(self, ctx, volume: int):
@@ -394,7 +391,7 @@ class MusicModule(commands.Cog, CogFactory):
             current = player.current
             if ctx.display:
                 embed = Embed(
-                    title=f"\u25B6 Now playing: {current['title']}",
+                    title=f"\u25B6\uFE0F Now playing: {current['title']}",
                     description=f"by {current['uploader']}",
                     color=self.EMBED_COLOR,
                     url=current["webpage_url"],

--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -28,6 +28,7 @@ from yt_dlp import YoutubeDL
 
 from acme_bot.autoloader import CogFactory, autoloaded
 from acme_bot.config.properties import MUSIC_EXTRACTOR_MAX_WORKERS
+from acme_bot.convutils import to_int
 from acme_bot.music.extractor import MusicExtractor
 from acme_bot.music.player import MusicPlayer
 from acme_bot.music.ui import ConfirmAddTracks, SelectTrack
@@ -265,7 +266,7 @@ class MusicModule(commands.Cog, CogFactory):
         ARGUMENTS
             offset - number of tracks to rewind (default: 1)
         """
-        offset = int(offset)
+        offset = to_int(offset)
         async with self.__get_player(ctx) as player:
             player.move(-offset)
 
@@ -277,7 +278,7 @@ class MusicModule(commands.Cog, CogFactory):
         ARGUMENTS
             offset - number of tracks to skip (default: 1)
         """
-        offset = int(offset)
+        offset = to_int(offset)
         async with self.__get_player(ctx) as player:
             player.move(offset)
 
@@ -372,7 +373,7 @@ class MusicModule(commands.Cog, CogFactory):
         RETURN VALUE
             The new volume value as an integer.
         """
-        volume = int(volume)
+        volume = to_int(volume)
         async with self.__get_player(ctx) as player:
             player.volume = volume
         if ctx.display:
@@ -412,7 +413,7 @@ class MusicModule(commands.Cog, CogFactory):
         RETURN VALUE
             The removed track URL as a string.
         """
-        offset = int(offset)
+        offset = to_int(offset)
         async with self.__get_player(ctx) as player:
             removed = player.remove(offset - 1 if offset >= 1 else offset)
             if ctx.display:

--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -414,7 +414,6 @@ class MusicModule(commands.Cog, CogFactory):
     @play_snd.before_invoke
     @play_url.before_invoke
     @volume.before_invoke
-    # pylint: disable=unused-private-member
     async def _ensure_voice_or_join(self, ctx):
         """Ensure that the sender is in a voice channel,
         otherwise join the sender's voice channel."""
@@ -449,7 +448,6 @@ class MusicModule(commands.Cog, CogFactory):
     @pause.before_invoke
     @resume.before_invoke
     @stop.before_invoke
-    # pylint: disable=unused-private-member
     async def _ensure_voice_or_fail(self, ctx):
         """Ensure that the sender is in a voice channel, or throw
         an exception that will prevent the command from executing."""
@@ -462,7 +460,6 @@ class MusicModule(commands.Cog, CogFactory):
     @queue.before_invoke
     @remove.before_invoke
     @skip.before_invoke
-    # pylint: disable=unused-private-member
     async def _ensure_voice_and_non_empty_queue(self, ctx):
         """Ensure that the sender is in a voice channel, a MusicPlayer
         for that channel exists and the queue is not empty."""

--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -117,7 +117,7 @@ class MusicModule(commands.Cog, CogFactory):
 
     def __generate_access_code(self):
         while code := int("".join(choices(string.digits, k=self.ACCESS_CODE_LENGTH))):
-            if not any(player.access_code == code for player in self.__players):
+            if not any(player.access_code == code for player in self.__players.values()):
                 return code
         assert False
 

--- a/acme_bot/music/player.py
+++ b/acme_bot/music/player.py
@@ -140,7 +140,7 @@ class MusicPlayer(MusicQueue):
 
     @property
     def access_code(self):
-        """Return the player's access code."""
+        """Return the player's globally unique access code."""
         return self.__access_code
 
     @property
@@ -202,7 +202,6 @@ class MusicPlayer(MusicQueue):
             self.__state = PlayerState.PLAYING
             self.__ctx.voice_client.resume()
         elif self.__state == PlayerState.STOPPED:
-            self.__state = PlayerState.PLAYING
             await self.start_player(self.current)
         else:
             raise commands.CommandError("This player is not paused!")
@@ -236,18 +235,16 @@ class MusicPlayer(MusicQueue):
         with self.__lock:
             if err:
                 log.error(err)
-                return
-            if (
+            elif (
                 self._should_stop(self.__next_offset)
                 and self.__state == PlayerState.PLAYING
             ):
                 self.__state = PlayerState.STOPPED
                 run_coroutine_threadsafe(
-                    self.__ctx.send("\u2757 The queue is empty, stopping the player."),
+                    self.__ctx.send("\u2757\uFE0F The queue is empty, player stopped."),
                     self.__ctx.bot.loop,
                 )
-                return
-            if self.__state in (PlayerState.PLAYING, PlayerState.PAUSED):
+            elif self.__state in (PlayerState.PLAYING, PlayerState.PAUSED):
                 current = self._next(self.__next_offset)
                 self.__next_offset = 1  # Set next_offset back to the default value of 1
                 run_coroutine_threadsafe(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -144,6 +144,16 @@ class AsyncList(list):
             yield item
 
 
+class AsyncContextManager:
+    """Object with an async context manager."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_):
+        return False
+
+
 @dataclass
 class FakeContext:
     """Fake discord.py context for testing modules that interact with the text chat."""
@@ -165,6 +175,9 @@ class FakeContext:
 
     def history(self, **_):
         return self.hist
+
+    def typing(self):
+        return AsyncContextManager()
 
     async def send(
         self,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -35,6 +35,7 @@ class StubChannel:
     id: int = 123456789
     name: str = "Test Channel"
     ctx: Optional[object] = None
+    members: list[object] = field(default_factory=list)
 
     async def connect(self):
         if self.ctx is not None:
@@ -161,6 +162,7 @@ class FakeContext:
     tts: list[bool]
     messages: list[str]
     views: list[object]
+    embeds: list[object]
     hist: AsyncList[object]
     references: list[object]
     delete_after: list[float]
@@ -181,12 +183,13 @@ class FakeContext:
 
     async def send(
         self,
-        content,
+        content="",
         *,
         tts=False,
         file=None,
         delete_after=None,
         reference=None,
+        embed=None,
         view=None
     ):
         self.messages.append(content)
@@ -194,6 +197,7 @@ class FakeContext:
         self.files.append(file)
         self.delete_after.append(delete_after)
         self.references.append(reference)
+        self.embeds.append(embed)
         self.views.append(view)
 
     async def send_pages(self, *args, **kwargs):
@@ -346,6 +350,7 @@ def fake_ctx(fake_bot, fake_message, fake_voice_client):
         [],
         [],
         [],
+        [],
         AsyncList(),
         [],
         [],
@@ -361,6 +366,7 @@ def fake_ctx_history(fake_bot, stub_file_message, fake_voice_client):
         [],
         [],
         [],
+        [],
         AsyncList([stub_file_message]),
         [],
         [],
@@ -373,6 +379,7 @@ def fake_ctx_history(fake_bot, stub_file_message, fake_voice_client):
 @pytest.fixture
 def fake_ctx_no_voice(fake_bot, fake_message):
     return FakeContext(
+        [],
         [],
         [],
         [],

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import pytest
 
+from acme_bot.music import MusicModule
 from acme_bot.music.extractor import MusicExtractor
 from acme_bot.music.player import MusicPlayer, PlayerState
 from acme_bot.music.queue import MusicQueue
@@ -32,6 +33,7 @@ class StubChannel:
     """Stub discord.py voice channel object."""
 
     id: int = 123456789
+    name: str = "Test Channel"
 
 
 @dataclass
@@ -407,3 +409,8 @@ async def remote_control_module(stub_bot, player):
 @pytest.fixture
 def shell_module():
     return ShellModule()
+
+
+@pytest.fixture
+def music_module(stub_bot, extractor):
+    return MusicModule(stub_bot, extractor)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -62,6 +62,10 @@ class StubBot:
     """Stub discord.py bot instance object."""
 
     loop: AbstractEventLoop
+    events: list[object] = field(default_factory=list)
+
+    def dispatch(self, event, *args):
+        self.events.append((event, *args))
 
 
 @dataclass

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -58,7 +58,7 @@ class StubUser:
 
 
 @dataclass
-class StubBot:
+class FakeBot:
     """Stub discord.py bot instance object."""
 
     loop: AbstractEventLoop
@@ -156,7 +156,7 @@ class FakeContext:
     delete_after: list[float]
     files: list[Optional[str]]
 
-    bot: StubBot
+    bot: FakeBot
     voice_client: Optional[FakeVoiceClient]
 
     display: bool = True
@@ -318,8 +318,8 @@ def stub_user():
 
 
 @pytest.fixture
-async def stub_bot():
-    return StubBot(get_running_loop())
+async def fake_bot():
+    return FakeBot(get_running_loop())
 
 
 @pytest.fixture
@@ -328,7 +328,7 @@ def fake_voice_client():
 
 
 @pytest.fixture
-def fake_ctx(stub_bot, fake_message, fake_voice_client):
+def fake_ctx(fake_bot, fake_message, fake_voice_client):
     return FakeContext(
         [],
         [],
@@ -337,13 +337,13 @@ def fake_ctx(stub_bot, fake_message, fake_voice_client):
         [],
         [],
         [],
-        stub_bot,
+        fake_bot,
         fake_voice_client,
     )
 
 
 @pytest.fixture
-def fake_ctx_history(stub_bot, stub_file_message, fake_voice_client):
+def fake_ctx_history(fake_bot, stub_file_message, fake_voice_client):
     return FakeContext(
         [],
         [],
@@ -352,13 +352,13 @@ def fake_ctx_history(stub_bot, stub_file_message, fake_voice_client):
         [],
         [],
         [],
-        stub_bot,
+        fake_bot,
         fake_voice_client,
     )
 
 
 @pytest.fixture
-def fake_ctx_no_voice(stub_bot, fake_message):
+def fake_ctx_no_voice(fake_bot, fake_message):
     return FakeContext(
         [],
         [],
@@ -367,7 +367,7 @@ def fake_ctx_no_voice(stub_bot, fake_message):
         [],
         [],
         [],
-        stub_bot,
+        fake_bot,
         None,
     )
 
@@ -420,8 +420,8 @@ async def select_track_view(stub_user, fake_player, youtube_playlist):
 
 
 @pytest.fixture
-async def remote_control_module(stub_bot, player):
-    cog = RemoteControlModule(stub_bot, None)
+async def remote_control_module(fake_bot, player):
+    cog = RemoteControlModule(fake_bot, None)
     await cog._handle_player_created(player)
     return cog
 
@@ -432,5 +432,5 @@ def shell_module():
 
 
 @pytest.fixture
-def music_module(stub_bot, extractor):
-    return MusicModule(stub_bot, extractor)
+def music_module(fake_bot, extractor):
+    return MusicModule(fake_bot, extractor)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -432,5 +432,8 @@ def shell_module():
 
 
 @pytest.fixture
-def music_module(fake_bot, extractor):
-    return MusicModule(fake_bot, extractor)
+def music_module(fake_bot, extractor, player_with_tracks):
+    cog = MusicModule(fake_bot, extractor)
+    cog._MusicModule__players[StubChannel.id] = player_with_tracks
+    cog._MusicModule__access_codes.add(player_with_tracks.access_code)
+    return cog

--- a/test/test_music.py
+++ b/test/test_music.py
@@ -1,0 +1,35 @@
+import pytest
+from discord.ext import commands
+
+from acme_bot.music import MusicPlayer, export_entry_list
+
+
+async def test_leave_channel_returns_tracks(
+    fake_ctx, player_with_tracks, fake_bot, music_module
+):
+    tracks = await music_module.leave(music_module, fake_ctx)
+    with pytest.raises(KeyError):
+        music_module._get_player(fake_ctx)
+
+    event = fake_bot.events[0]
+    assert event[0] == "acme_bot_player_deleted"
+    assert event[1] == player_with_tracks
+    assert tracks == export_entry_list(player_with_tracks.get_tracks()[0])
+
+
+async def test_ensure_voice_or_join_sends_event(
+    fake_ctx_no_voice, fake_bot, music_module
+):
+    fake_ctx_no_voice.author.voice.channel.ctx = fake_ctx_no_voice
+    await music_module._ensure_voice_or_join(fake_ctx_no_voice)
+    assert music_module._get_player(fake_ctx_no_voice).channel_id == 123456789
+
+    event = fake_bot.events[0]
+    assert event[0] == "acme_bot_player_created"
+    assert isinstance(event[1], MusicPlayer)
+
+
+async def test_ensure_voice_or_join_throws(fake_ctx_no_voice, music_module):
+    fake_ctx_no_voice.author.voice = None
+    with pytest.raises(commands.CommandError):
+        await music_module._ensure_voice_or_join(fake_ctx_no_voice)

--- a/test/test_music.py
+++ b/test/test_music.py
@@ -3,6 +3,7 @@ from discord.ext import commands
 
 from acme_bot.music import MusicPlayer, export_entry_list
 from acme_bot.music.player import PlayerState
+from test.conftest import StubChannel, StubVoice
 
 
 async def test_leave_channel_returns_tracks(
@@ -15,7 +16,14 @@ async def test_leave_channel_returns_tracks(
     event = fake_bot.events[0]
     assert event[0] == "acme_bot_player_deleted"
     assert event[1] == player_with_tracks
-    assert tracks == export_entry_list(player_with_tracks.get_tracks()[0])
+    expected = "\n".join(
+        [
+            "https://www.youtube.com/watch?v=Ee_uujKuJM0    foo - 3:02",
+            "https://www.youtube.com/watch?v=FNKPYhXmzo0    boo - 9:06",
+            "",
+        ]
+    )
+    assert tracks == expected
 
 
 async def test_list_urls_extracts_track_urls(fake_ctx, music_module):
@@ -61,6 +69,83 @@ async def test_pause_sets_player_pause(fake_ctx, player_with_tracks, music_modul
     assert player_with_tracks.state is PlayerState.PAUSED
 
 
+async def test_queue_returns_tracks(fake_ctx, music_module):
+    result = await music_module.queue(music_module, fake_ctx)
+    expected = "\n".join(
+        [
+            "https://www.youtube.com/watch?v=Ee_uujKuJM0    foo - 3:02",
+            "https://www.youtube.com/watch?v=FNKPYhXmzo0    boo - 9:06",
+            "",
+        ]
+    )
+    assert result == expected
+
+
+async def test_resume_unsets_player_pause(fake_ctx, player_with_tracks, music_module):
+    player_with_tracks.pause()
+    await music_module.resume(music_module, fake_ctx)
+    assert player_with_tracks.state is PlayerState.PLAYING
+
+
+async def test_clear_clears_player_queue(fake_ctx, player_with_tracks, music_module):
+    result = await music_module.clear(music_module, fake_ctx)
+    expected = "\n".join(
+        [
+            "https://www.youtube.com/watch?v=Ee_uujKuJM0    foo - 3:02",
+            "https://www.youtube.com/watch?v=FNKPYhXmzo0    boo - 9:06",
+            "",
+        ]
+    )
+    assert result == expected
+    assert player_with_tracks.is_empty()
+    assert player_with_tracks.state is PlayerState.IDLE
+
+
+async def test_stop_sets_player_stop(fake_ctx, player_with_tracks, music_module):
+    await music_module.stop(music_module, fake_ctx)
+    assert player_with_tracks.state is PlayerState.STOPPED
+
+
+async def test_volume_sets_player_volume(fake_ctx, player_with_tracks, music_module):
+    await music_module.volume(music_module, fake_ctx, 50)
+    assert player_with_tracks.volume == 50
+
+
+async def test_volume_throws_on_string_argument(fake_ctx, music_module):
+    with pytest.raises(commands.CommandError):
+        await music_module.volume(music_module, fake_ctx, "foo")
+
+
+async def test_current_returns_current_track(fake_ctx, music_module):
+    result = await music_module.current(music_module, fake_ctx)
+    assert result == "https://www.youtube.com/watch?v=Ee_uujKuJM0    foo - 3:02\n"
+
+
+async def test_remove_returns_removed_track(fake_ctx, player_with_tracks, music_module):
+    result = await music_module.remove(music_module, fake_ctx, 0)
+    assert result == "https://www.youtube.com/watch?v=Ee_uujKuJM0    foo - 3:02\n"
+    assert len(player_with_tracks.get_tracks()[0]) == 1
+
+
+async def test_remove_throws_on_string_argument(fake_ctx, music_module):
+    with pytest.raises(commands.CommandError):
+        await music_module.remove(music_module, fake_ctx, "foo")
+
+
+async def test_quit_channel_if_empty_sends_event(
+    fake_ctx, fake_bot, player_with_tracks, music_module
+):
+    before = StubVoice(StubChannel(123456789))
+    after = StubVoice(None)
+    await music_module._quit_channel_if_empty(None, before, after)
+    with pytest.raises(KeyError):
+        music_module._get_player(fake_ctx)
+
+    event = fake_bot.events[0]
+    assert event[0] == "acme_bot_player_deleted"
+    assert event[1] == player_with_tracks
+
+
 async def test_ensure_voice_or_join_sends_event(
     fake_ctx_no_voice, fake_bot, music_module
 ):
@@ -77,3 +162,17 @@ async def test_ensure_voice_or_join_throws(fake_ctx_no_voice, music_module):
     fake_ctx_no_voice.author.voice = None
     with pytest.raises(commands.CommandError):
         await music_module._ensure_voice_or_join(fake_ctx_no_voice)
+
+
+async def test_ensure_voice_or_fail_throws(fake_ctx_no_voice, music_module):
+    fake_ctx_no_voice.author.voice = None
+    with pytest.raises(commands.CommandError):
+        await music_module._ensure_voice_or_fail(fake_ctx_no_voice)
+
+
+async def test_ensure_voice_and_non_empty_queue_throws(
+    fake_ctx, player_with_tracks, music_module
+):
+    player_with_tracks.clear()
+    with pytest.raises(commands.CommandError):
+        await music_module._ensure_voice_and_non_empty_queue(fake_ctx)

--- a/test/test_music.py
+++ b/test/test_music.py
@@ -3,7 +3,7 @@ from discord.ext import commands
 
 from acme_bot.music import MusicPlayer
 from acme_bot.music.player import PlayerState
-from test.conftest import StubChannel, StubVoice
+from conftest import StubChannel, StubVoice
 
 
 async def test_leave_channel_returns_tracks(

--- a/test/test_music.py
+++ b/test/test_music.py
@@ -2,6 +2,7 @@ import pytest
 from discord.ext import commands
 
 from acme_bot.music import MusicPlayer, export_entry_list
+from acme_bot.music.player import PlayerState
 
 
 async def test_leave_channel_returns_tracks(
@@ -15,6 +16,49 @@ async def test_leave_channel_returns_tracks(
     assert event[0] == "acme_bot_player_deleted"
     assert event[1] == player_with_tracks
     assert tracks == export_entry_list(player_with_tracks.get_tracks()[0])
+
+
+async def test_list_urls_extracts_track_urls(fake_ctx, music_module):
+    urls = await music_module.list_urls(
+        music_module,
+        fake_ctx,
+        "https://soundcloud.com/baz/foo #comment",
+        "https://www.youtube.com/watch?v=3SdSKZFoUa0",
+    )
+    expected = "\n".join(
+        [
+            "https://soundcloud.com/baz/foo    foo - 3:46",
+            "https://www.youtube.com/watch?v=3SdSKZFoUa0    baz - 1:26:18",
+            "",
+        ]
+    )
+    assert urls == expected
+
+
+async def test_list_urls_throws_on_empty_list(fake_ctx, music_module):
+    with pytest.raises(commands.CommandError):
+        await music_module.list_urls(music_module, fake_ctx)
+
+
+async def test_previous_throws_on_string_argument(fake_ctx, music_module):
+    with pytest.raises(commands.CommandError):
+        await music_module.previous(music_module, fake_ctx, "foo")
+
+
+async def test_skip_throws_on_string_argument(fake_ctx, music_module):
+    with pytest.raises(commands.CommandError):
+        await music_module.skip(music_module, fake_ctx, "foo")
+
+
+async def test_loop_sets_player_loop(fake_ctx, player_with_tracks, music_module):
+    result = await music_module.loop(music_module, fake_ctx, False)
+    assert player_with_tracks.loop is False
+    assert result is False
+
+
+async def test_pause_sets_player_pause(fake_ctx, player_with_tracks, music_module):
+    await music_module.pause(music_module, fake_ctx)
+    assert player_with_tracks.state is PlayerState.PAUSED
 
 
 async def test_ensure_voice_or_join_sends_event(

--- a/test/test_music.py
+++ b/test/test_music.py
@@ -1,7 +1,7 @@
 import pytest
 from discord.ext import commands
 
-from acme_bot.music import MusicPlayer, export_entry_list
+from acme_bot.music import MusicPlayer
 from acme_bot.music.player import PlayerState
 from test.conftest import StubChannel, StubVoice
 


### PR DESCRIPTION
- Refactored music player UI
- Fixed generate_access_code in MusicModule
- Access codes are now managed with a set
- Added tests for the following commands:
    - leave
    - list-urls
    - previous
    - skip
    - loop
    - pause
    - queue
    - resume
    - clear
    - stop
    - volume
    - current
    - remove
- Fix MusicModule players locking