### PR TITLE
Provide access to the remote control frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ Dependencies
 License
 -------
 
-[GNU Affero General Public License v3](https://opensource.org/licenses/AGPL-3.0)
+[GNU Affero General Public License v3](https://opensource.org/license/agpl-v3)

--- a/acme_bot/config/default.conf
+++ b/acme_bot/config/default.conf
@@ -5,7 +5,7 @@
 # ==============================================================================
 # Credentials
 #
-# SECURITY NOTE: Users with filesystem permissions may read configuration files.
+# SECURITY NOTE: Users with the right filesystem permissions may read this file.
 # It is recommended to define these properties in environment variables instead.
 # ==============================================================================
 
@@ -39,6 +39,9 @@ LOG_LEVEL='INFO'
 # ==============================================================================
 # Music module
 # ==============================================================================
+
+# Base URL of the acme-bot-remote frontend application. (optional)
+#MUSIC_REMOTE_BASE_URL='https://example.com/remote'
 
 # Maximum number of processes to use for extracting music tracks. (optional)
 #MUSIC_EXTRACTOR_MAX_WORKERS=4

--- a/acme_bot/config/properties.py
+++ b/acme_bot/config/properties.py
@@ -31,4 +31,5 @@ COMMAND_PREFIX = ConfigProperty("COMMAND_PREFIX", str)
 LOG_LEVEL = ConfigProperty("LOG_LEVEL", logging.getLevelName)
 
 # Music module
+MUSIC_REMOTE_BASE_URL = ConfigProperty("MUSIC_REMOTE_BASE_URL", URL)
 MUSIC_EXTRACTOR_MAX_WORKERS = ConfigProperty("MUSIC_EXTRACTOR_MAX_WORKERS", int)

--- a/acme_bot/music/__init__.py
+++ b/acme_bot/music/__init__.py
@@ -87,6 +87,7 @@ class MusicModule(commands.Cog, CogFactory):
         self.__lock = Lock()
         self.__players = {}
         self.__access_codes = set()
+        self.__remote_id = None
 
         self.bot = bot
         self.extractor = extractor
@@ -408,6 +409,13 @@ class MusicModule(commands.Cog, CogFactory):
                     log.info("Voice channel ID %s is now empty, disconnecting", prev.id)
                     async with self.__players[prev.id] as player:
                         await self.__delete_player(player)
+
+    @commands.Cog.listener("on_acme_bot_remote_id")
+    async def _register_remote_id(self, remote_id):
+        """Register the remote ID of the current instance."""
+        async with self.__lock:
+            self.__remote_id = remote_id
+            log.debug("Registered RemoteControlModule with remote ID %s", remote_id)
 
     @join.before_invoke
     @play.before_invoke

--- a/acme_bot/music/ui.py
+++ b/acme_bot/music/ui.py
@@ -14,10 +14,12 @@
 #  You should have received a copy of the GNU Affero General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from discord import ui, ButtonStyle
+from discord import ui, ButtonStyle, Embed
 
 from acme_bot.music.extractor import add_expire_time
 from acme_bot.music.player import PlayerState
+
+EMBED_COLOR = 0xFF0000
 
 
 class VerifiedView(ui.View):
@@ -114,3 +116,27 @@ class SelectTrack(VerifiedView):
         )
         button.callback = button_pressed
         self.add_item(button)
+
+
+def current_track_embed(current):
+    """Create an embed describing the current track."""
+    embed = Embed(
+        title=f"\u25B6\uFE0F Now playing: {current['title']}",
+        description=f"by {current['uploader']}",
+        color=EMBED_COLOR,
+        url=current["webpage_url"],
+    )
+    if "thumbnail" in current:
+        embed.set_thumbnail(url=current["thumbnail"])
+    return embed
+
+
+def remote_embed(base_url, remote_id, access_code):
+    """Create an embed with a link to the remote control application."""
+    url = base_url % {"rid": remote_id, "ac": access_code}
+    embed = Embed(
+        title="\u27A1\uFE0F Click here to access the web player.",
+        color=EMBED_COLOR,
+        url=url,
+    )
+    return embed

--- a/acme_bot/remote_control/__init__.py
+++ b/acme_bot/remote_control/__init__.py
@@ -60,8 +60,9 @@ class RemoteControlModule(commands.Cog, CogFactory):
         return ext_control
 
     async def cog_load(self):
-        self.__connection.reconnect_callbacks.add(self.__handle_command_stream)
-        self.__bot.loop.create_task(self.__handle_command_stream())
+        await self.__declare_command_queue()
+        self.__connection.reconnect_callbacks.add(self.__declare_command_queue)
+        self.__bot.dispatch("acme_bot_remote_id", self.__uuid.hex)
 
     async def cog_unload(self):
         await self.__connection.close()
@@ -77,28 +78,25 @@ class RemoteControlModule(commands.Cog, CogFactory):
             del self.__players[player.access_code]
 
     async def _run_command(self, message):
-        log.debug("Received message: %s", message)
-        try:
-            command = RemoteCommandModel.model_validate_json(message).root
-            async with self.__lock, self.__players[command.code] as player:
-                await command.run(player)
-        except KeyError as exc:
-            log.debug("Invalid access code: '%s'", exc.args[0])
-        except (ValidationError, ValueError) as exc:
-            log.exception("Invalid command: %s", message, exc_info=exc)
-        except (commands.CommandError, IndexError) as exc:
-            log.exception("Command failed: %s", message, exc_info=exc)
+        async with message.process():
+            content = message.body
+            log.debug("Received message: %s", content)
+            try:
+                command = RemoteCommandModel.model_validate_json(content).root
+                async with self.__lock, self.__players[command.code] as player:
+                    await command.run(player)
+            except KeyError as exc:
+                log.debug("Invalid access code: '%s'", exc.args[0])
+            except (ValidationError, ValueError) as exc:
+                log.exception("Invalid command: %s", content, exc_info=exc)
+            except (commands.CommandError, IndexError) as exc:
+                log.exception("Command failed: %s", content, exc_info=exc)
 
-    async def __handle_command_stream(self, *_):
+    async def __declare_command_queue(self, *_):
         log.info("Connected to AMQP broker at '%s'", censor_url(self.__connection.url))
-        async with self.__connection:
-            channel = await self.__connection.channel()
-            exchange = await channel.declare_exchange(
-                "acme_bot_remote", aio_pika.ExchangeType.FANOUT, durable=True
-            )
-            queue = await channel.declare_queue(auto_delete=True)
-            await queue.bind(exchange)
-            async with queue.iterator() as message_stream:
-                async for msg in message_stream:
-                    async with msg.process():
-                        await self._run_command(msg.body)
+        channel = await self.__connection.channel()
+        exchange = await channel.declare_exchange("acme_bot_remote", durable=True)
+        queue = await channel.declare_queue(auto_delete=True)
+        await queue.bind(exchange, routing_key=self.__uuid.hex)
+        await queue.consume(self._run_command)
+        log.info("Listening for remote commands with ID %s", self.__uuid.hex)

--- a/acme_bot/remote_control/__init__.py
+++ b/acme_bot/remote_control/__init__.py
@@ -67,12 +67,12 @@ class RemoteControlModule(commands.Cog, CogFactory):
         await self.__connection.close()
 
     @commands.Cog.listener("on_acme_bot_player_created")
-    async def _handle_player_created(self, player):
+    async def _register_player(self, player):
         async with self.__lock:
             self.__players[player.access_code] = player
 
     @commands.Cog.listener("on_acme_bot_player_deleted")
-    async def _handle_player_deleted(self, player):
+    async def _delete_player(self, player):
         async with self.__lock:
             del self.__players[player.access_code]
 

--- a/acme_bot/remote_control/__init__.py
+++ b/acme_bot/remote_control/__init__.py
@@ -16,6 +16,7 @@
 
 import logging
 from asyncio import Lock
+from uuid import uuid4
 
 import aio_pika
 from aiormq.tools import censor_url
@@ -39,6 +40,7 @@ class RemoteControlModule(commands.Cog, CogFactory):
         self.__players = {}
 
         self.__bot = bot
+        self.__uuid = uuid4()
         self.__connection = connection
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,14 @@ python-dotenv = "^1.0.0"
 textX = "^3.1.1"
 yt-dlp = "2023.7.6"
 
-[tool.poetry.group.test.dependencies]
-pytest = "^7.4.0"
-pytest-asyncio = "^0.21.1"
-
-[tool.poetry.group.lint.dependencies]
+[tool.poetry.group.dev.dependencies]
 black = "23.7.0"
 flake8 = "^6.1.0"
 pylint = "^2.17.5"
+
+[tool.poetry.group.test.dependencies]
+pytest = "^7.4.0"
+pytest-asyncio = "^0.21.1"
 
 [tool.poetry.build]
 script = "commit_info.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "acme-bot"
-version = "1.0.0-dev"
+version = "1.1.0-dev"
 description = "Discord music bot with a custom shell language"
 license = "AGPL-3.0-or-later"
 authors = ["kmolski <krzysztof.molski29@gmail.com>"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -156,6 +156,16 @@ class AsyncContextManager:
 
 
 @dataclass
+class FakeAmqpMessage:
+    """Fake aio_pika message object."""
+
+    body: bytes = b""
+
+    def process(self):
+        return AsyncContextManager()
+
+
+@dataclass
 class FakeContext:
     """Fake discord.py context for testing modules that interact with the text chat."""
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -274,6 +274,7 @@ def youtube_playlist():
                 "https://rr3---sn-oxup5-3ufs.googlevideo.com/videoplayback"
                 + "?expire=1582257033"
             ),
+            "thumbnail": "https://i.ytimg.com/vi/Ee_uujKuJM0/hqdefault.jpg",
         },
         {
             "id": "FNKPYhXmzo0",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -442,7 +442,7 @@ async def select_track_view(stub_user, fake_player, youtube_playlist):
 @pytest.fixture
 async def remote_control_module(fake_bot, player):
     cog = RemoteControlModule(fake_bot, None)
-    await cog._handle_player_created(player)
+    await cog._register_player(player)
     return cog
 
 

--- a/test/test_music_ui.py
+++ b/test/test_music_ui.py
@@ -1,4 +1,7 @@
+from yarl import URL
+
 from acme_bot.music.player import PlayerState
+from acme_bot.music.ui import remote_embed
 
 
 async def test_confirm_add_has_add_and_cancel_buttons(confirm_add_tracks_view):
@@ -102,3 +105,10 @@ async def test_select_cancels(
     assert fake_message.view is None
     assert player.get_tracks() == ([], [])
     assert player.state == PlayerState.IDLE
+
+
+def test_remote_embed_has_valid_link():
+    remote_id = "e2329439f3f046bf9fd6045bcccb154d"
+    access_code = 123456
+    embed = remote_embed(URL("https://example.com/?rcs=foo"), remote_id, access_code)
+    assert embed.url == f"https://example.com/?rcs=foo&rid={remote_id}&ac={access_code}"

--- a/test/test_remote_control.py
+++ b/test/test_remote_control.py
@@ -1,5 +1,5 @@
 from acme_bot.music.player import PlayerState
-from test.conftest import FakeAmqpMessage
+from conftest import FakeAmqpMessage
 
 
 async def test_run_command_handles_invalid_json(remote_control_module):

--- a/test/test_remote_control.py
+++ b/test/test_remote_control.py
@@ -1,37 +1,45 @@
 from acme_bot.music.player import PlayerState
+from test.conftest import FakeAmqpMessage
 
 
 async def test_run_command_handles_invalid_json(remote_control_module):
-    await remote_control_module._run_command(b"garbage")
+    message = FakeAmqpMessage(b"garbage")
+    await remote_control_module._run_command(message)
 
 
 async def test_run_command_handles_invalid_command(remote_control_module):
-    message = b"""
+    message = FakeAmqpMessage(
+        b"""
         {
             "command": "null",
             "args": []
         }
-    """
+        """
+    )
     await remote_control_module._run_command(message)
 
 
 async def test_run_command_handles_nonexistent_player(remote_control_module):
-    message = b"""
+    message = FakeAmqpMessage(
+        b"""
         {
             "op": "resume",
             "code": 1234
         }
-    """
+        """
+    )
     await remote_control_module._run_command(message)
 
 
 async def test_run_command_handles_command_error(remote_control_module):
-    message = b"""
+    message = FakeAmqpMessage(
+        b"""
         {
             "op": "resume",
             "code": 123456
         }
-    """
+        """
+    )
     await remote_control_module._run_command(message)
 
 
@@ -41,12 +49,14 @@ async def test_run_command_pauses_on_pause_command(
     assert player.state == PlayerState.IDLE
     assert fake_voice_client.paused is False
 
-    message = b"""
+    message = FakeAmqpMessage(
+        b"""
         {
             "op": "pause",
             "code": 123456
         }
-    """
+        """
+    )
     await remote_control_module._run_command(message)
     assert player.state == PlayerState.PAUSED
     assert fake_voice_client.paused is True
@@ -58,12 +68,14 @@ async def test_run_command_stops_on_stop_command(
     assert player.state == PlayerState.IDLE
     assert fake_voice_client.stopped is False
 
-    message = b"""
+    message = FakeAmqpMessage(
+        b"""
         {
             "op": "stop",
             "code": 123456
         }
-    """
+        """
+    )
     await remote_control_module._run_command(message)
     assert player.state == PlayerState.STOPPED
     assert fake_voice_client.stopped is True
@@ -74,12 +86,14 @@ async def test_run_command_resumes_on_resume_command(
 ):
     player.pause()
 
-    message = b"""
+    message = FakeAmqpMessage(
+        b"""
         {
             "op": "resume",
             "code": 123456
         }
-    """
+        """
+    )
     await remote_control_module._run_command(message)
     assert player.state == PlayerState.PLAYING
     assert fake_voice_client.paused is False

--- a/test/test_remote_control.py
+++ b/test/test_remote_control.py
@@ -1,34 +1,38 @@
-import pytest
-from pydantic import ValidationError
-
 from acme_bot.music.player import PlayerState
 
 
-async def test_run_command_throws_on_invalid_json(remote_control_module):
-    with pytest.raises(ValueError):
-        await remote_control_module._run_command(b"garbage")
+async def test_run_command_handles_invalid_json(remote_control_module):
+    await remote_control_module._run_command(b"garbage")
 
 
-async def test_run_command_throws_on_invalid_command(remote_control_module):
+async def test_run_command_handles_invalid_command(remote_control_module):
     message = b"""
         {
             "command": "null",
             "args": []
         }
     """
-    with pytest.raises(ValidationError):
-        await remote_control_module._run_command(message)
+    await remote_control_module._run_command(message)
 
 
-async def test_run_command_throws_on_nonexistent_player(remote_control_module):
+async def test_run_command_handles_nonexistent_player(remote_control_module):
     message = b"""
         {
             "op": "resume",
             "code": 1234
         }
     """
-    with pytest.raises(KeyError):
-        await remote_control_module._run_command(message)
+    await remote_control_module._run_command(message)
+
+
+async def test_run_command_handles_command_error(remote_control_module):
+    message = b"""
+        {
+            "op": "resume",
+            "code": 123456
+        }
+    """
+    await remote_control_module._run_command(message)
 
 
 async def test_run_command_pauses_on_pause_command(


### PR DESCRIPTION
- Renamed event handlers in RemoteControlModule
- Added MUSIC_REMOTE_BASE_URL config property
- Improved test coverage
- Improved RemoteControlModule reconnection code
- UUIDs are now assigned to every bot instance
- Added embed with remote link to channel join message
- Reorganized dependency groups