### PR TITLE
feat(remote-api): Add clear, loop and volume remote commands

### DIFF
--- a/acme_bot/remote_control/schema.py
+++ b/acme_bot/remote_control/schema.py
@@ -14,9 +14,9 @@
 #  You should have received a copy of the GNU Affero General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Literal
+from typing import Literal, Union
 
-from pydantic import BaseModel, RootModel, Field
+from pydantic import BaseModel, Field, RootModel, conint
 
 
 class RemoteCommand(BaseModel):
@@ -57,7 +57,43 @@ class ResumeCommand(RemoteCommand):
         await player.resume()
 
 
+class ClearCommand(RemoteCommand):
+    """Remote command to clear the player's queue."""
+
+    op: Literal["clear"]
+
+    async def run(self, player):
+        player.clear()
+
+
+class LoopCommand(RemoteCommand):
+    """Remote command to set the player's loop."""
+
+    op: Literal["loop"]
+    enabled: bool
+
+    async def run(self, player):
+        player.loop = self.enabled
+
+
+class VolumeCommand(RemoteCommand):
+    """Remote command to set the player's volume."""
+
+    op: Literal["volume"]
+    value: conint(ge=0, le=100)
+
+    async def run(self, player):
+        player.volume = self.value
+
+
 class RemoteCommandModel(RootModel):
     """Root model for remote control commands."""
 
-    root: PauseCommand | StopCommand | ResumeCommand = Field(discriminator="op")
+    root: Union[
+        PauseCommand,
+        StopCommand,
+        ResumeCommand,
+        ClearCommand,
+        LoopCommand,
+        VolumeCommand,
+    ] = Field(discriminator="op")

--- a/test/test_remote_control.py
+++ b/test/test_remote_control.py
@@ -1,5 +1,6 @@
-from acme_bot.music.player import PlayerState
 from conftest import FakeAmqpMessage
+
+from acme_bot.music.player import PlayerState
 
 
 async def test_run_command_handles_invalid_json(remote_control_module):
@@ -97,3 +98,52 @@ async def test_run_command_resumes_on_resume_command(
     await remote_control_module._run_command(message)
     assert player.state == PlayerState.PLAYING
     assert fake_voice_client.paused is False
+
+
+async def test_run_command_clears_queue_on_clear_command(
+    remote_control_module, player, fake_voice_client
+):
+    player.append({"id": 123})
+    message = FakeAmqpMessage(
+        b"""
+        {
+            "op": "clear",
+            "code": 123456
+        }
+        """
+    )
+    await remote_control_module._run_command(message)
+    assert player.is_empty() is True
+    assert player.state == PlayerState.IDLE
+
+
+async def test_run_command_sets_loop_on_loop_command(
+    remote_control_module, player, fake_voice_client
+):
+    message = FakeAmqpMessage(
+        b"""
+        {
+            "op": "loop",
+            "enabled": false,
+            "code": 123456
+        }
+        """
+    )
+    await remote_control_module._run_command(message)
+    assert player.loop is False
+
+
+async def test_run_command_sets_volume_on_volume_command(
+    remote_control_module, player, fake_voice_client
+):
+    message = FakeAmqpMessage(
+        b"""
+        {
+            "op": "volume",
+            "value": 42,
+            "code": 123456
+        }
+        """
+    )
+    await remote_control_module._run_command(message)
+    assert player.volume == 42


### PR DESCRIPTION
Add new remote API commands corresponding to `clear`, `loop`, and `volume` bot commands.

Closes #99.