### PR TITLE
fix(remote-api): Use AMQP topics to broadcast player data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "acme-bot"
-version = "1.2.0-dev"
+version = "1.3.2-dev"
 description = "Discord music bot with a custom shell language"
 license = "AGPL-3.0-or-later"
 authors = ["kmolski <krzysztof.molski29@gmail.com>"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,7 @@
 from asyncio import get_running_loop, sleep, AbstractEventLoop, Queue
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, field
+from uuid import uuid4
 
 import pytest
 
@@ -528,4 +529,4 @@ def amqp_exchange(amqp_channel):
 
 @pytest.fixture
 async def player_observer(amqp_exchange, player):
-    return MusicPlayerObserver(amqp_exchange, player, get_running_loop())
+    return MusicPlayerObserver(amqp_exchange, player, uuid4(), get_running_loop())


### PR DESCRIPTION
Closes #119.

Enables https://github.com/kmolski/acme-bot-remote/issues/41.